### PR TITLE
Dealing with group's feed from graph api v2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fb-groups
 
-## Data origin
+## Data
 Using Facebook Graph API v2.3 one is able to acquire data from an User's group.
 Of course this is possible only if you have being granted the _user\_groups_ permission. 
 Anyways, since Graph API v2.4 the [_user\_groups_ permission is deprecated](https://developers.facebook.com/docs/apps/changelog#v2_4_deprecations). This deprecation means you can only get data from a group managed by the user, through _user\_managed_groups_ permission.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,32 @@
 # fb-groups
 
-## Known limitations
-Since I'm starting from data acquired through [facebook-export](https://www.npmjs.com/package/facebook-export), there are some limitations:
-* There are no nested comments (replies as Facebooks call it).
-* Comments don't have likes associated with them.
-  *   Back in the day it was not a trivial task to retrieve it.
-* The photos weren't imported. So no TAGS for now.
+## Data origin
+Using Facebook Graph API v2.3 one is able to acquire data from an User's group.
+Of course this is possible only if you have being granted the _user\_groups_ permission. 
+Anyways, since Graph API v2.4 the [_user\_groups_ permission is deprecated](https://developers.facebook.com/docs/apps/changelog#v2_4_deprecations). This deprecation means you can only get data from a group managed by the user, through _user\_managed_groups_ permission.
+But good news, we can use v2.3 until [July 8, 2017](https://developers.facebook.com/docs/apps/changelog#versions).
 
-* TODO update these limitations
-  * not getting data from facebook-export anymore
-  * I'm almost sure that we can read photos now too.
-  * We can read post mentions.
+### Data acquired
+By doing a GET request to [_/v2.3/{group-id}/members_](https://developers.facebook.com/docs/graph-api/reference/v2.3/group/members) is possible to obtain all users of the group. Data acquired:
+* User id.
+* The person's full name. 
+
+By doing a GET request to [_/v2.3/{group-id}/feed_](https://developers.facebook.com/docs/graph-api/reference/v2.3/group/feed) is possible to obtain a group's feed. This feed is an array of [Posts](https://developers.facebook.com/docs/graph-api/reference/post). By performing some test I was able to identify Posts in the group's feed as:
+* Photos
+* Text
+
+Each post has the following fields:
+* Comments: Each comment has its content and the user who commented. As well as the total count of likes received in the comment.
+* Likes: A like has the user who performed it.
+* Message: Text content.
+* Tags: 
+ * _with\_tags_ : Users tagged as being 'with' the Post's author.
+ * _story\_tags_: Users tagged in the Post's text message.
+
+**Right now the text content of both Posts and Comments are not being stored or analyzed.**
+
+### Known limitations
+The following interactions are not being imported right now:
+* Comment's replies (nested comments)
+* Likes on a post.
+To retrieve a Comment's replies one have to perform an API request for each comment. The same goes for retrieving the users who liked a Comment.

--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@ Since I'm starting from data acquired through [facebook-export](https://www.npmj
   *   Back in the day it was not a trivial task to retrieve it.
 * The photos weren't imported. So no TAGS for now.
 
+* TODO update these limitations
+  * not getting data from facebook-export anymore
+  * I'm almost sure that we can read photos now too.
+  * We can read post mentions.

--- a/src/model/fbdata/GroupFeed.java
+++ b/src/model/fbdata/GroupFeed.java
@@ -1,13 +1,7 @@
 package model.fbdata;
 
-import java.io.BufferedWriter;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStreamWriter;
-import java.io.UnsupportedEncodingException;
-import java.io.Writer;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -21,6 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class GroupFeed {
 
 	private static final String JSON_EXTENSION = ".json";
+
 	@JsonProperty("data")
 	public List<Post> posts;
 
@@ -30,31 +25,30 @@ public class GroupFeed {
 
 	public static void main(String[] args)
 			throws JsonParseException, JsonMappingException, IOException {
+		List<Post> allPosts = retrieveAllPosts();
+
+		System.out.println("Total posts: " + allPosts.size());
+		Long totalInteractions = allPosts.stream()
+				.mapToLong(p -> p.getInteractions().size()).sum();
+		System.out.println("Total Interactions: " + totalInteractions);
+	}
+
+	public static List<Post> retrieveAllPosts()
+			throws IOException, JsonParseException, JsonMappingException {
 		ObjectMapper mapper = new ObjectMapper();
 		mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
 				false);
 
-		// InputStream is = GroupFeed.class
-		// .getResourceAsStream("/data/maristao_novo_feed_2.json");
 		List<Post> allPosts = new LinkedList<>();
-		List<String> files = Arrays.asList("1", "2", "3");
+		List<String> files = Arrays.asList("1", "2", "3", "4", "5", "6", "7",
+				"8");
 
 		for (String fileName : files) {
 			GroupFeed feed = parseGroupFeedFromJson(mapper, fileName);
 			printFeedRead(fileName, feed);
 			allPosts.addAll(feed.getPosts());
 		}
-
-//		InputStream is = GroupFeed.class.getResourceAsStream("/data/3.json");
-//		takeBuggedCharOut(is);
-
-		// GroupFeed feed = mapper.readValue(json.substring(1),
-		// GroupFeed.class);
-
-		System.out.println("Total posts: " + allPosts.size());
-		Long totalInteractions = allPosts.stream()
-				.mapToLong(p -> p.getInteractions().size()).sum();
-		System.out.println("Total Interactions: " + totalInteractions);
+		return allPosts;
 	}
 
 	private static GroupFeed parseGroupFeedFromJson(ObjectMapper mapper,
@@ -73,23 +67,6 @@ public class GroupFeed {
 				.mapToLong(p -> p.getInteractions().size()).sum();
 		System.out.println("Interactions: " + totalInteractions);
 		System.out.println("================================================");
-	}
-
-	private static void takeBuggedCharOut(InputStream is) throws IOException,
-			UnsupportedEncodingException, FileNotFoundException {
-		String json = convertStreamToString(is);
-		json.replace("\r\n", "\\n");
-
-		try (Writer out = new BufferedWriter(new OutputStreamWriter(
-				new FileOutputStream("teste.json"), "UTF-8"))) {
-			out.write(json);
-		}
-	}
-
-	static String convertStreamToString(java.io.InputStream is) {
-		java.util.Scanner s = new java.util.Scanner(is, "UTF-8")
-				.useDelimiter("\\A");
-		return s.hasNext() ? s.next() : "";
 	}
 
 }

--- a/src/model/fbdata/GroupFeed.java
+++ b/src/model/fbdata/GroupFeed.java
@@ -61,7 +61,7 @@ public class GroupFeed {
 
 	private static void printFeedRead(String fileName, GroupFeed feed) {
 		System.out.println("================================================");
-		System.out.println("File '" + fileName + JSON_EXTENSION + "'read.");
+		System.out.println("File '" + fileName + JSON_EXTENSION + "' read.");
 		System.out.println("Posts: " + feed.getPosts().size());
 		Long totalInteractions = feed.getPosts().stream()
 				.mapToLong(p -> p.getInteractions().size()).sum();

--- a/src/model/fbdata/GroupFeed.java
+++ b/src/model/fbdata/GroupFeed.java
@@ -1,9 +1,18 @@
 package model.fbdata;
 
+import java.io.BufferedWriter;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.io.UnsupportedEncodingException;
+import java.io.Writer;
+import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -11,19 +20,76 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class GroupFeed {
 
+	private static final String JSON_EXTENSION = ".json";
+	@JsonProperty("data")
+	public List<Post> posts;
+
+	public List<Post> getPosts() {
+		return posts;
+	}
+
 	public static void main(String[] args)
 			throws JsonParseException, JsonMappingException, IOException {
 		ObjectMapper mapper = new ObjectMapper();
 		mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
 				false);
 
-		InputStream is = GroupFeed.class
-				.getResourceAsStream("/data/maristao.json");
-		List<Post> posts = mapper.readValue(is, mapper.getTypeFactory()
-				.constructCollectionLikeType(List.class, Post.class));
+		// InputStream is = GroupFeed.class
+		// .getResourceAsStream("/data/maristao_novo_feed_2.json");
+		List<Post> allPosts = new LinkedList<>();
+		List<String> files = Arrays.asList("1", "2", "3");
 
-		Long totalInteractions = posts.stream()
+		for (String fileName : files) {
+			GroupFeed feed = parseGroupFeedFromJson(mapper, fileName);
+			printFeedRead(fileName, feed);
+			allPosts.addAll(feed.getPosts());
+		}
+
+//		InputStream is = GroupFeed.class.getResourceAsStream("/data/3.json");
+//		takeBuggedCharOut(is);
+
+		// GroupFeed feed = mapper.readValue(json.substring(1),
+		// GroupFeed.class);
+
+		System.out.println("Total posts: " + allPosts.size());
+		Long totalInteractions = allPosts.stream()
 				.mapToLong(p -> p.getInteractions().size()).sum();
 		System.out.println("Total Interactions: " + totalInteractions);
 	}
+
+	private static GroupFeed parseGroupFeedFromJson(ObjectMapper mapper,
+			String fileName) throws IOException, JsonParseException,
+					JsonMappingException {
+		String fullFileName = "/data/" + fileName + JSON_EXTENSION;
+		InputStream is = GroupFeed.class.getResourceAsStream(fullFileName);
+		return mapper.readValue(is, GroupFeed.class);
+	}
+
+	private static void printFeedRead(String fileName, GroupFeed feed) {
+		System.out.println("================================================");
+		System.out.println("File '" + fileName + JSON_EXTENSION + "'read.");
+		System.out.println("Posts: " + feed.getPosts().size());
+		Long totalInteractions = feed.getPosts().stream()
+				.mapToLong(p -> p.getInteractions().size()).sum();
+		System.out.println("Interactions: " + totalInteractions);
+		System.out.println("================================================");
+	}
+
+	private static void takeBuggedCharOut(InputStream is) throws IOException,
+			UnsupportedEncodingException, FileNotFoundException {
+		String json = convertStreamToString(is);
+		json.replace("\r\n", "\\n");
+
+		try (Writer out = new BufferedWriter(new OutputStreamWriter(
+				new FileOutputStream("teste.json"), "UTF-8"))) {
+			out.write(json);
+		}
+	}
+
+	static String convertStreamToString(java.io.InputStream is) {
+		java.util.Scanner s = new java.util.Scanner(is, "UTF-8")
+				.useDelimiter("\\A");
+		return s.hasNext() ? s.next() : "";
+	}
+
 }

--- a/src/model/fbdata/Interaction.java
+++ b/src/model/fbdata/Interaction.java
@@ -40,4 +40,8 @@ public class Interaction {
 				+ "]";
 	}
 
+	public boolean isSelfInteraction() {
+		return to.equals(from);
+	}
+
 }

--- a/src/model/fbdata/Mention.java
+++ b/src/model/fbdata/Mention.java
@@ -26,7 +26,7 @@ public class Mention {
 
 	@Override
 	public String toString() {
-		return "Mention [id=" + id + ", name=" + name + "]";
+		return "Mention [User Mentioned=" + getUserMentioned() + "]";
 	}
 
 	public User getUserMentioned() {

--- a/src/model/fbdata/Mention.java
+++ b/src/model/fbdata/Mention.java
@@ -16,6 +16,15 @@ public class Mention {
 
 	private String name;
 
+	public Mention() {
+
+	}
+
+	public Mention(User user) {
+		id = user.getId();
+		name = user.getName();
+	}
+
 	public Long getId() {
 		return id;
 	}
@@ -31,6 +40,37 @@ public class Mention {
 
 	public User getUserMentioned() {
 		return new User(id, name);
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Mention other = (Mention) obj;
+		if (id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		} else if (!name.equals(other.name))
+			return false;
+		return true;
 	}
 
 	public static void main(String[] args)

--- a/src/model/fbdata/Post.java
+++ b/src/model/fbdata/Post.java
@@ -27,6 +27,12 @@ public class Post {
 	@JsonProperty("likes")
 	private PostLikes postLikes;
 
+	@JsonProperty("story_tags")
+	private StoryTags storyTags;
+
+	@JsonProperty("with_tags")
+	private WithTags withTags;
+
 	public User getAuthor() {
 		return author;
 	}
@@ -41,6 +47,14 @@ public class Post {
 		if (postLikes == null)
 			return Collections.emptyList();
 		return postLikes.getLikesFrom();
+	}
+
+	public List<Mention> getWithTags() {
+		return withTags.getTags();
+	}
+
+	public List<Mention> getStoryTags() {
+		return storyTags.getTags();
 	}
 
 	@Override
@@ -81,9 +95,12 @@ public class Post {
 		mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
 				false);
 
-		InputStream is = Post.class.getResourceAsStream("/data/post_big.json");
+		InputStream is = Post.class
+				.getResourceAsStream("/data/post_with_mentions.json");
 		Post testObj = mapper.readValue(is, Post.class);
 		System.out.println(testObj);
+		System.out.println("Story tags: " + testObj.getStoryTags());
+		System.out.println("With tags: " + testObj.getWithTags());
 		System.out.println(testObj.getLikes().size() + " likes");
 		System.out.println(testObj.getComments().size() + " comments");
 		System.out.println(testObj.getInteractions().size() + " interactions");

--- a/src/model/fbdata/Post.java
+++ b/src/model/fbdata/Post.java
@@ -18,6 +18,9 @@ import model.fbdata.Interaction.Type;
 
 public class Post {
 
+	@JsonProperty("id")
+	private String id;
+
 	@JsonProperty("from")
 	private User author;
 
@@ -32,6 +35,13 @@ public class Post {
 
 	@JsonProperty("with_tags")
 	private WithTags withTags;
+
+	@JsonProperty("message_tags")
+	private PostMessageTags messageTags;
+
+	public String getId() {
+		return id;
+	}
 
 	public User getAuthor() {
 		return author;
@@ -59,6 +69,12 @@ public class Post {
 		if (storyTags == null)
 			return Collections.emptyList();
 		return storyTags.getTags();
+	}
+
+	public List<Mention> getMessageTags() {
+		if (messageTags == null)
+			return Collections.emptyList();
+		return messageTags.getTags();
 	}
 
 	@Override

--- a/src/model/fbdata/Post.java
+++ b/src/model/fbdata/Post.java
@@ -53,7 +53,7 @@ public class Post {
 		return postComments.getComments();
 	}
 
-	public List<User> getLikes() {
+	public List<User> getUsersWhoLiked() {
 		if (postLikes == null)
 			return Collections.emptyList();
 		return postLikes.getLikesFrom();
@@ -79,7 +79,7 @@ public class Post {
 
 	@Override
 	public String toString() {
-		return "Post [author=" + author + ", \nlikes=" + getLikes()
+		return "Post [author=" + author + ", \nlikes=" + getUsersWhoLiked()
 				+ ", \ncomments=" + getComments() + "]";
 	}
 
@@ -94,8 +94,8 @@ public class Post {
 
 	private Collection<Interaction> getLikesInteractions() {
 		List<Interaction> likesInteractions = new ArrayList<Interaction>(
-				getLikes().size());
-		for (User userWhoLiked : getLikes()) {
+				getUsersWhoLiked().size());
+		for (User userWhoLiked : getUsersWhoLiked()) {
 			likesInteractions
 					.add(new Interaction(userWhoLiked, author, Type.LIKE));
 		}
@@ -147,7 +147,7 @@ public class Post {
 		System.out.println("With tags: " + testObj.getWithTags());
 		System.out.println(testObj.getStoryTags().size() + " Story tags");
 		System.out.println(testObj.getWithTags().size() + " With tags");
-		System.out.println(testObj.getLikes().size() + " likes");
+		System.out.println(testObj.getUsersWhoLiked().size() + " likes");
 		System.out.println(testObj.getComments().size() + " comments");
 		System.out.println(testObj.getInteractions().size() + " interactions");
 		Collection<Interaction> postInteractions = testObj.getInteractions();

--- a/src/model/fbdata/Post.java
+++ b/src/model/fbdata/Post.java
@@ -67,26 +67,50 @@ public class Post {
 		List<Interaction> interactions = new LinkedList<Interaction>();
 		interactions.addAll(getLikesInteractions());
 		interactions.addAll(getCommentsInteractions());
+		interactions.addAll(getStoryTagsInteractions());
+		interactions.addAll(getWithTagsInteractions());
 		return interactions;
 	}
 
 	private Collection<Interaction> getLikesInteractions() {
-		List<Interaction> likes = new ArrayList<Interaction>(getLikes().size());
+		List<Interaction> likesInteractions = new ArrayList<Interaction>(
+				getLikes().size());
 		for (User userWhoLiked : getLikes()) {
-			likes.add(new Interaction(userWhoLiked, author, Type.LIKE));
+			likesInteractions
+					.add(new Interaction(userWhoLiked, author, Type.LIKE));
 		}
-		return likes;
+		return likesInteractions;
 	}
 
 	private Collection<Interaction> getCommentsInteractions() {
-		List<Interaction> comments = new ArrayList<Interaction>(
+		List<Interaction> commentsInteractions = new ArrayList<Interaction>(
 				getComments().size());
 		for (Comment comment : getComments()) {
-			comments.add(
+			commentsInteractions.add(
 					new Interaction(comment.getAuthor(), author, Type.COMMENT));
-			comments.addAll(comment.getMentionsInteractions());
+			commentsInteractions.addAll(comment.getMentionsInteractions());
 		}
-		return comments;
+		return commentsInteractions;
+	}
+
+	private Collection<Interaction> getStoryTagsInteractions() {
+		List<Interaction> storyTagsInteractions = new ArrayList<Interaction>(
+				getStoryTags().size());
+		for (Mention mention : getStoryTags()) {
+			storyTagsInteractions.add(new Interaction(author,
+					mention.getUserMentioned(), Type.MENTION));
+		}
+		return storyTagsInteractions;
+	}
+
+	private Collection<Interaction> getWithTagsInteractions() {
+		List<Interaction> withTagsInteractions = new ArrayList<Interaction>(
+				getWithTags().size());
+		for (Mention mention : getWithTags()) {
+			withTagsInteractions.add(new Interaction(author,
+					mention.getUserMentioned(), Type.MENTION));
+		}
+		return withTagsInteractions;
 	}
 
 	public static void main(String[] args)
@@ -101,6 +125,8 @@ public class Post {
 		System.out.println(testObj);
 		System.out.println("Story tags: " + testObj.getStoryTags());
 		System.out.println("With tags: " + testObj.getWithTags());
+		System.out.println(testObj.getStoryTags().size() + " Story tags");
+		System.out.println(testObj.getWithTags().size() + " With tags");
 		System.out.println(testObj.getLikes().size() + " likes");
 		System.out.println(testObj.getComments().size() + " comments");
 		System.out.println(testObj.getInteractions().size() + " interactions");

--- a/src/model/fbdata/Post.java
+++ b/src/model/fbdata/Post.java
@@ -50,10 +50,14 @@ public class Post {
 	}
 
 	public List<Mention> getWithTags() {
+		if (withTags == null)
+			return Collections.emptyList();
 		return withTags.getTags();
 	}
 
 	public List<Mention> getStoryTags() {
+		if (storyTags == null)
+			return Collections.emptyList();
 		return storyTags.getTags();
 	}
 

--- a/src/model/fbdata/PostMessageTags.java
+++ b/src/model/fbdata/PostMessageTags.java
@@ -1,0 +1,30 @@
+package model.fbdata;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+
+public class PostMessageTags {
+
+	private List<Mention> tags = new LinkedList<>();
+
+	public List<Mention> getTags() {
+		return tags;
+	}
+
+	@JsonAnySetter
+	public void set(String id, List<Mention> mention) {
+		tags.addAll(mention);
+	}
+
+	@Override
+	public String toString() {
+		return "PostMessageTags [tags=" + tags + "]";
+	}
+
+	public int size() {
+		return tags.size();
+	}
+
+}

--- a/src/model/fbdata/StoryTags.java
+++ b/src/model/fbdata/StoryTags.java
@@ -17,4 +17,14 @@ public class StoryTags {
 	public void set(String id, List<Mention> mention) {
 		tags.addAll(mention);
 	}
+
+	@Override
+	public String toString() {
+		return "StoryTags [tags=" + tags + "]";
+	}
+
+	public int size() {
+		return tags.size();
+	}
+
 }

--- a/src/model/fbdata/StoryTags.java
+++ b/src/model/fbdata/StoryTags.java
@@ -1,0 +1,20 @@
+package model.fbdata;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+
+public class StoryTags {
+
+	private List<Mention> tags = new LinkedList<>();
+
+	public List<Mention> getTags() {
+		return tags;
+	}
+
+	@JsonAnySetter
+	public void set(String id, List<Mention> mention) {
+		tags.addAll(mention);
+	}
+}

--- a/src/model/fbdata/WithTags.java
+++ b/src/model/fbdata/WithTags.java
@@ -1,5 +1,6 @@
 package model.fbdata;
 
+import java.util.Collections;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -7,10 +8,19 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class WithTags {
 
 	@JsonProperty("data")
-	private List<Mention> tags;
+	private List<Mention> tags = Collections.emptyList();
 
 	public List<Mention> getTags() {
 		return tags;
+	}
+
+	@Override
+	public String toString() {
+		return "WithTags [tags=" + tags + "]";
+	}
+	
+	public int size() {
+		return tags.size();
 	}
 
 }

--- a/src/model/fbdata/WithTags.java
+++ b/src/model/fbdata/WithTags.java
@@ -1,0 +1,16 @@
+package model.fbdata;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class WithTags {
+
+	@JsonProperty("data")
+	private List<Mention> tags;
+
+	public List<Mention> getTags() {
+		return tags;
+	}
+
+}

--- a/src/model/graph/GroupNetworkGraph.java
+++ b/src/model/graph/GroupNetworkGraph.java
@@ -25,7 +25,21 @@ public class GroupNetworkGraph {
 		return false;
 	}
 
-	public void addInteraction(Interaction interaction) {
+	/**
+	 * Does not add self-interactions.
+	 * 
+	 * @return <tt>true</tt> if the interaction was added successfully,
+	 *         <tt>false</tt> otherwise.
+	 */
+	public boolean addInteraction(Interaction interaction) {
+		if (!interaction.isSelfInteraction()) {
+			doAddInteraction(interaction);
+			return true;
+		}
+		return false;
+	}
+
+	private void doAddInteraction(Interaction interaction) {
 		Node nodeFrom = retrieveUserNode(interaction.getFrom());
 		Node nodeTo = retrieveUserNode(interaction.getTo());
 		nodeFrom.addInteractionWith(nodeTo, interaction.getType());

--- a/src/model/graph/GroupNetworkGraph.java
+++ b/src/model/graph/GroupNetworkGraph.java
@@ -13,8 +13,16 @@ public class GroupNetworkGraph {
 
 	private Integer numEdges = 0;
 
-	public void addNode(User user) {
-		nodes.put(user, new Node(user));
+	/**
+	 * @return <tt>true</tt> if the node was added successfully, <tt>false</tt>
+	 *         otherwise
+	 */
+	public boolean addNode(User user) {
+		if (!nodes.containsKey(user)) {
+			nodes.put(user, new Node(user));
+			return true;
+		}
+		return false;
 	}
 
 	public void addInteraction(Interaction interaction) {
@@ -41,6 +49,10 @@ public class GroupNetworkGraph {
 
 	public boolean hasNodeForUser(User user) {
 		return nodes.containsKey(user);
+	}
+
+	public Node getUserNode(User user) {
+		return nodes.get(user);
 	}
 
 	public Integer getNumEdges() {

--- a/src/model/graph/Main.java
+++ b/src/model/graph/Main.java
@@ -50,6 +50,7 @@ public class Main {
 	private static void addInteractions()
 			throws JsonParseException, JsonMappingException, IOException {
 		List<Post> posts = retrievePosts();
+		System.out.println("Total posts:" + posts.size());
 		for (Post post : posts) {
 			for (Interaction interaction : post.getInteractions()) {
 				graph.addInteraction(interaction);

--- a/src/model/graph/Node.java
+++ b/src/model/graph/Node.java
@@ -16,11 +16,11 @@ public class Node {
 
 	private HashMap<Node, Interactions> neighborsInteractedWith = new HashMap<>();
 
-	public Node(User user) {
+	protected Node(User user) {
 		this.user = user;
 	}
 
-	public void addInteractionWith(Node interactedNode,
+	protected void addInteractionWith(Node interactedNode,
 			Interaction.Type interactionType) {
 		addInteraction(interactedNode, interactionType);
 		outDegree += 1;

--- a/test/data/post.json
+++ b/test/data/post.json
@@ -1,0 +1,130 @@
+
+    {
+      "id": "groupId_postId",
+      "from": {
+        "name": "diego",
+        "id": "666"
+      },
+      "to": {
+        "data": [
+          {
+            "name": "GROUP",
+            "privacy": "SECRET",
+            "id": "groupId"
+          },
+          {
+            "name": "murillo",
+            "id": "123"
+          },
+          {
+            "name": "gustavo",
+            "id": "987"
+          }
+        ]
+      },
+      "with_tags": {
+        "data": [
+          {
+            "name": "murillo",
+            "id": "123"
+          },
+          {
+            "name": "gustavo",
+            "id": "987"
+          }
+        ]
+      },
+      "message": "Post tagging murillo and gustavo.\nAlso in with_tags.",
+      "message_tags": {
+        "15": [
+          {
+            "id": "123",
+            "name": "murillo",
+            "type": "user",
+            "offset": 15,
+            "length": 14
+          }
+        ],
+        "32": [
+          {
+            "id": "987",
+            "name": "gustavo",
+            "type": "user",
+            "offset": 32,
+            "length": 15
+          }
+        ]
+      },
+      "actions": [
+        {
+          "name": "Comment",
+          "link": "https://www.facebook.com/groupId/posts/postId"
+        },
+        {
+          "name": "Like",
+          "link": "https://www.facebook.com/groupId/posts/postId"
+        },
+        {
+          "name": "Create Group Chat",
+          "link": "https://www.facebook.com/groups/groupId/"
+        }
+      ],
+      "privacy": {
+        "value": "CUSTOM",
+        "description": "",
+        "friends": "",
+        "allow": "",
+        "deny": ""
+      },
+      "type": "status",
+      "created_time": "2016-04-09T15:19:22+0000",
+      "updated_time": "2016-04-09T15:19:44+0000",
+      "is_hidden": false,
+      "subscribed": true,
+      "is_expired": false,
+      "likes": {
+        "data": [
+          {
+            "id": "666",
+            "name": "diego"
+          }
+        ],
+        "paging": {
+          "cursors": {
+            "before": "MTAxNTMzNDgzNTg5ODUyMjUZD",
+            "after": "MTAxNTMzNDgzNTg5ODUyMjUZD"
+          }
+        }
+      },
+      "comments": {
+        "data": [
+          {
+            "created_time": "2016-04-09T15:19:44+0000",
+            "from": {
+              "name": "diego",
+              "id": "666"
+            },
+            "message": "Comentário para completar. Taggeando murillo",
+            "can_remove": true,
+            "like_count": 0,
+            "message_tags": [
+              {
+                "id": "123",
+                "length": 14,
+                "name": "murillo",
+                "offset": 37,
+                "type": "user"
+              }
+            ],
+            "user_likes": false,
+            "id": "1000"
+          }
+        ],
+        "paging": {
+          "cursors": {
+            "before": "WTI5dGJXVnVkRjlqZAFhKemIzSTZAOVGM1TURJME9UVXlNalkwTXprNU9qRTBOakF5TVRVeE9EUT0ZD",
+            "after": "WTI5dGJXVnVkRjlqZAFhKemIzSTZAOVGM1TURJME9UVXlNalkwTXprNU9qRTBOakF5TVRVeE9EUT0ZD"
+          }
+        }
+      }
+    }

--- a/test/data/post.json
+++ b/test/data/post.json
@@ -118,6 +118,18 @@
             ],
             "user_likes": false,
             "id": "1000"
+          },
+		  {
+            "created_time": "2016-04-09T18:25:18+0000",
+            "from": {
+              "name": "murillo",
+              "id": "123"
+            },
+            "message": "WHATUP",
+            "can_remove": true,
+            "like_count": 0,
+            "user_likes": false,
+            "id": "1111"
           }
         ],
         "paging": {

--- a/test/data/post.json
+++ b/test/data/post.json
@@ -53,7 +53,16 @@
             "offset": 32,
             "length": 15
           }
-        ]
+        ],
+		"89": [
+          {
+            "id": "666",
+            "name": "diego",
+            "type": "user",
+            "offset": 89,
+            "length": 14
+          }
+		 ]
       },
       "actions": [
         {

--- a/test/model/graph/GrouphNetworkGraphTest.java
+++ b/test/model/graph/GrouphNetworkGraphTest.java
@@ -1,6 +1,6 @@
 package model.graph;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import org.junit.Test;
 
@@ -12,15 +12,55 @@ public class GrouphNetworkGraphTest {
 
 	private GroupNetworkGraph graph = new GroupNetworkGraph();
 
+	private User u1 = new User(1L, "1");
+	private User u2 = new User(2L, "2");
+
 	@Test
 	public void shouldCreateNodesIfTheyDontExistWhenAddingAnInteraction() {
-		User u1 = new User(1L, "1");
-		User u2 = new User(2L, "2");
+		graph.addInteraction(commentFromUser1ToUser2());
 
-		graph.addInteraction(new Interaction(u1, u2, Type.COMMENT));
-		
 		assertTrue(graph.hasNodeForUser(u1));
 		assertTrue(graph.hasNodeForUser(u2));
+	}
+
+	private Interaction commentFromUser1ToUser2() {
+		return new Interaction(u1, u2, Type.COMMENT);
+	}
+
+	@Test
+	public void shouldReturnTrueWhenSuccessfullyAddedANode() {
+		boolean successfullyAdded = graph.addNode(u1);
+		assertTrue(successfullyAdded);
+	}
+
+	@Test
+	public void shouldReturnFalseWhenAddingAnExistentNode() {
+		graph.addNode(u1);
+		boolean successfullyAdded = graph.addNode(u1);
+		assertFalse(successfullyAdded);
+	}
+
+	@Test
+	public void shouldNotCreateNewNodeWhenTryingToAddExistingNode() {
+		graph.addNode(u1);
+		graph.addInteraction(commentFromUser1ToUser2());
+		Node originalNode = graph.getUserNode(u1);
+
+		graph.addNode(u1);
+		Node nodeAddedAgain = graph.getUserNode(u1);
+
+		assertThatNodeAddedAgainIsEqualToOriginalNode(originalNode,
+				nodeAddedAgain);
+	}
+
+	private void assertThatNodeAddedAgainIsEqualToOriginalNode(
+			Node originalNode, Node nodeAddedAgain) {
+		assertEquals(originalNode, nodeAddedAgain);
+		assertEquals(originalNode.getInDegree(), nodeAddedAgain.getInDegree());
+		assertEquals(originalNode.getOutDegree(),
+				nodeAddedAgain.getOutDegree());
+		assertEquals(originalNode.getNeighbors(),
+				nodeAddedAgain.getNeighbors());
 	}
 
 }

--- a/test/model/graph/GrouphNetworkGraphTest.java
+++ b/test/model/graph/GrouphNetworkGraphTest.java
@@ -16,6 +16,21 @@ public class GrouphNetworkGraphTest {
 	private User u2 = new User(2L, "2");
 
 	@Test
+	public void shouldReturnTrueWhenAddingAnInteraction() {
+		boolean successfullyAdded = graph
+				.addInteraction(commentFromUser1ToUser2());
+		assertTrue(successfullyAdded);
+	}
+
+	@Test
+	public void shouldReturnFalseAndNotAddSelfInteraction() {
+		boolean successfullyAdded = graph
+				.addInteraction(new Interaction(u1, u1, Type.LIKE));
+		assertFalse(successfullyAdded);
+		assertEquals(0, graph.getNumEdges().intValue());
+	}
+
+	@Test
 	public void shouldCreateNodesIfTheyDontExistWhenAddingAnInteraction() {
 		graph.addInteraction(commentFromUser1ToUser2());
 

--- a/test/model/graph/InteractionsTest.java
+++ b/test/model/graph/InteractionsTest.java
@@ -25,17 +25,19 @@ public class InteractionsTest {
 	@Test
 	public void addingCommentAddsTotalsCorrectly() throws Exception {
 		interactions.add(Type.COMMENT);
-		assertEquals(previousTotalMentions, interactions.getTotalMentions());
-		assertEquals(1, interactions.getTotalComments());
-		assertEquals(1, interactions.getTotal());
+		assertEquals(previousTotalMentions,
+				(int) interactions.getTotalMentions());
+		assertEquals(1, (int) interactions.getTotalComments());
+		assertEquals(1, (int) interactions.getTotal());
 	}
 
 	@Test
 	public void addingMentionAddsTotalsCorrectly() throws Exception {
 		interactions.add(Type.MENTION);
-		assertEquals(previousTotalComments, interactions.getTotalComments());
-		assertEquals(1, interactions.getTotalMentions());
-		assertEquals(1, interactions.getTotal());
+		assertEquals(previousTotalComments,
+				(int) interactions.getTotalComments());
+		assertEquals(1, (int) interactions.getTotalMentions());
+		assertEquals(1, (int) interactions.getTotal());
 	}
 
 }

--- a/test/model/graph/NodeTest.java
+++ b/test/model/graph/NodeTest.java
@@ -26,16 +26,16 @@ public class NodeTest {
 	public void interactingNodeOnlyIncreasesOutDegree() throws Exception {
 		n1.addInteractionWith(n2, Interaction.Type.MENTION);
 
-		assertEquals(0, n1.getInDegree());
-		assertEquals(1, n1.getOutDegree());
+		assertEquals(0, (int) n1.getInDegree());
+		assertEquals(1, (int) n1.getOutDegree());
 	}
 
 	@Test
 	public void interactedNodeOnlyIncreasesInDegree() throws Exception {
 		n1.addInteractionWith(n2, Interaction.Type.MENTION);
 
-		assertEquals(1, n2.getInDegree());
-		assertEquals(0, n2.getOutDegree());
+		assertEquals(1, (int) n2.getInDegree());
+		assertEquals(0, (int) n2.getOutDegree());
 	}
 
 }

--- a/test/model/graph/PostTest.java
+++ b/test/model/graph/PostTest.java
@@ -7,7 +7,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.InputStream;
-import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -18,7 +17,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import model.fbdata.Comment;
-import model.fbdata.Interaction;
 import model.fbdata.Mention;
 import model.fbdata.Post;
 import model.fbdata.User;
@@ -121,4 +119,8 @@ public class PostTest {
 		assertTrue(comment.getMentions().isEmpty());
 	}
 
+	@Test
+	public void shouldHaveAllInteractions() {
+		assertEquals(6, post.getInteractions().size());
+	}
 }

--- a/test/model/graph/PostTest.java
+++ b/test/model/graph/PostTest.java
@@ -1,0 +1,81 @@
+package model.graph;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
+
+import java.io.InputStream;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.xml.internal.ws.policy.spi.AssertionCreationException;
+
+import model.fbdata.Mention;
+import model.fbdata.Post;
+import model.fbdata.User;
+import sun.invoke.empty.Empty;
+
+public class PostTest {
+
+	private static final User GUSTAVO = new User(987L, "gustavo");
+
+	private static final User MURILLO = new User(123L, "murillo");
+
+	private static final User DIEGO = new User(666L, "diego");
+
+	private static final String JSON_FILE_PATH = "/data/post.json";
+
+	private static Post post;
+
+	private static ObjectMapper mapper;
+
+	@BeforeClass
+	public static void setUpOnce() throws Exception {
+		mapper = new ObjectMapper();
+		mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
+				false);
+		InputStream is = PostTest.class.getResourceAsStream(JSON_FILE_PATH);
+		post = mapper.readValue(is, Post.class);
+	}
+
+	@Test
+	public void parsesTheID() {
+		assertEquals("groupId_postId", post.getId());
+	}
+
+	@Test
+	public void parsesTheAuthor() {
+		assertEquals(DIEGO, post.getAuthor());
+	}
+
+	@Test
+	public void shouldHaveWithTags() {
+		List<Mention> withTags = post.getWithTags();
+		assertThat(withTags, hasItem(mention(MURILLO)));
+		assertThat(withTags, hasItem(mention(GUSTAVO)));
+		assertEquals(2, withTags.size());
+	}
+
+	private Mention mention(User to) {
+		return new Mention(to);
+	}
+
+	@Test
+	public void shouldHaveNoStoryTags() throws Exception {
+		List<Mention> storyTags = post.getStoryTags();
+		assertTrue(storyTags.isEmpty());
+	}
+
+	@Test
+	public void shouldHaveMessageTags() {
+		List<Mention> messageTags = post.getMessageTags();
+		assertThat(messageTags, hasItem(mention(MURILLO)));
+		assertThat(messageTags, hasItem(mention(GUSTAVO)));
+		assertEquals(2, messageTags.size());
+	}
+
+}

--- a/test/model/graph/PostTest.java
+++ b/test/model/graph/PostTest.java
@@ -6,18 +6,15 @@ import static org.hamcrest.CoreMatchers.*;
 import java.io.InputStream;
 import java.util.List;
 
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sun.xml.internal.ws.policy.spi.AssertionCreationException;
 
 import model.fbdata.Mention;
 import model.fbdata.Post;
 import model.fbdata.User;
-import sun.invoke.empty.Empty;
 
 public class PostTest {
 
@@ -76,6 +73,13 @@ public class PostTest {
 		assertThat(messageTags, hasItem(mention(MURILLO)));
 		assertThat(messageTags, hasItem(mention(GUSTAVO)));
 		assertEquals(2, messageTags.size());
+	}
+
+	@Test
+	public void shouldHaveLikes() {
+		List<User> usersWhoLikedPost = post.getUsersWhoLiked();
+		assertThat(usersWhoLikedPost, hasItem(DIEGO));
+		assertEquals(1, usersWhoLikedPost.size());
 	}
 
 }

--- a/test/model/graph/PostTest.java
+++ b/test/model/graph/PostTest.java
@@ -23,6 +23,8 @@ import model.fbdata.User;
 
 public class PostTest {
 
+	private static final String POST_ID = "groupId_postId";
+
 	private static final int MURILLO_COMMENT_ID = 1111;
 
 	private static final long DIEGO_COMMENT_ID = 1000L;
@@ -49,17 +51,17 @@ public class PostTest {
 	}
 
 	@Test
-	public void parsesTheID() {
-		assertEquals("groupId_postId", post.getId());
+	public void shouldParsePostIdCorrectly() {
+		assertEquals(POST_ID, post.getId());
 	}
 
 	@Test
-	public void parsesTheAuthor() {
+	public void shouldParsePostAuthorCorrectly() {
 		assertEquals(DIEGO, post.getAuthor());
 	}
 
 	@Test
-	public void shouldHaveWithTags() {
+	public void shouldHaveAllWithTags() {
 		List<Mention> withTags = post.getWithTags();
 		assertThat(withTags, hasItem(mention(MURILLO)));
 		assertThat(withTags, hasItem(mention(GUSTAVO)));
@@ -77,7 +79,7 @@ public class PostTest {
 	}
 
 	@Test
-	public void shouldHaveMessageTags() {
+	public void shouldHaveAllMessageTags() {
 		List<Mention> messageTags = post.getMessageTags();
 		assertThat(messageTags, hasItem(mention(MURILLO)));
 		assertThat(messageTags, hasItem(mention(GUSTAVO)));
@@ -86,14 +88,14 @@ public class PostTest {
 	}
 
 	@Test
-	public void shouldHaveLikes() {
+	public void shouldHaveAllLikes() {
 		List<User> usersWhoLikedPost = post.getUsersWhoLiked();
 		assertThat(usersWhoLikedPost, hasItem(DIEGO));
 		assertEquals(1, usersWhoLikedPost.size());
 	}
 
 	@Test
-	public void shouldHaveComments() throws Exception {
+	public void shouldHaveAllComments() throws Exception {
 		assertEquals(2, post.getComments().size());
 	}
 

--- a/test/model/graph/PostTest.java
+++ b/test/model/graph/PostTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.InputStream;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -17,6 +18,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import model.fbdata.Comment;
+import model.fbdata.Interaction;
 import model.fbdata.Mention;
 import model.fbdata.Post;
 import model.fbdata.User;
@@ -81,7 +83,8 @@ public class PostTest {
 		List<Mention> messageTags = post.getMessageTags();
 		assertThat(messageTags, hasItem(mention(MURILLO)));
 		assertThat(messageTags, hasItem(mention(GUSTAVO)));
-		assertEquals(2, messageTags.size());
+		assertThat(messageTags, hasItem(mention(DIEGO)));
+		assertEquals(3, messageTags.size());
 	}
 
 	@Test

--- a/test/model/graph/PostTest.java
+++ b/test/model/graph/PostTest.java
@@ -1,10 +1,14 @@
 package model.graph;
 
-import static org.junit.Assert.*;
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.io.InputStream;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -12,11 +16,16 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import model.fbdata.Comment;
 import model.fbdata.Mention;
 import model.fbdata.Post;
 import model.fbdata.User;
 
 public class PostTest {
+
+	private static final int MURILLO_COMMENT_ID = 1111;
+
+	private static final long DIEGO_COMMENT_ID = 1000L;
 
 	private static final User GUSTAVO = new User(987L, "gustavo");
 
@@ -80,6 +89,33 @@ public class PostTest {
 		List<User> usersWhoLikedPost = post.getUsersWhoLiked();
 		assertThat(usersWhoLikedPost, hasItem(DIEGO));
 		assertEquals(1, usersWhoLikedPost.size());
+	}
+
+	@Test
+	public void shouldHaveComments() throws Exception {
+		assertEquals(2, post.getComments().size());
+	}
+
+	@Test
+	public void shouldHaveCommentFromDiegoTaggingMurillo() {
+		Comment comment = post.getComments().stream()
+				.filter(c -> c.getId() == DIEGO_COMMENT_ID)
+				.collect(Collectors.toList()).get(0);
+
+		assertThat(comment.getAuthor(), equalTo(DIEGO));
+
+		assertThat(comment.getMentions(), hasItem(mention(MURILLO)));
+		assertEquals(1, comment.getMentions().size());
+	}
+
+	@Test
+	public void shouldHaveCommentFromMurillo() {
+		Comment comment = post.getComments().stream()
+				.filter(c -> c.getId() == MURILLO_COMMENT_ID)
+				.collect(Collectors.toList()).get(0);
+
+		assertThat(comment.getAuthor(), equalTo(MURILLO));
+		assertTrue(comment.getMentions().isEmpty());
 	}
 
 }


### PR DESCRIPTION
Our README is starting to look good.
## Post

New data obtained. All these are computed as _Interaction_ and summed on _getInteractions()_
- _storyTags_
- _withTags_
- _messageTags_
## Node

Constructor and _addInteractionWith()_ made _protected_. Only _GroupNetworkGraph_ is calling them.
I think this decision makes sense based on how the graph abstraction was chosen to be exposed. 
## GroupNetworkGraph

Both _addNode()_ and _addInteraction()_ are now returning _true_ if the operation was successful, _false_ otherwise.
- Nothing happens when adding an existent node. (The previous behaviour was overwriting the existent node)
- The graph is not adding self interactions. 
## Tests
- Added an 'anonymized' post as a JSON file.
- Starting all test methods with 'should'
- More coverage. But we can always improve on that.
