### PR TITLE
Making sure the graph is constructed as intended

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,13 @@ Each post has the following fields:
 **Right now the text content of both Posts and Comments are not being stored or analyzed.**
 
 ### Known limitations
+#### Data
 The following interactions are not being imported right now:
-* Comment's replies (nested comments)
-* Likes on a post.
+* Comment's replies (nested comments) and its likes
+* Likes on a comment.
 To retrieve a Comment's replies one have to perform an API request for each comment. The same goes for retrieving the users who liked a Comment.
+
+#### Model
+What is being modeled as a graph are interactions between users. Interactions from an User to the Group is not being considered.
+
+Example: When an User posts something to the group, and this post does not tag anyone, does not have comments and likes, this post will not yield any interaction, therefore no changes will be made to the graph. 

--- a/src/model/fbdata/GroupFeed.java
+++ b/src/model/fbdata/GroupFeed.java
@@ -17,7 +17,7 @@ public class GroupFeed {
 	private static final String JSON_EXTENSION = ".json";
 
 	@JsonProperty("data")
-	public List<Post> posts;
+	private List<Post> posts;
 
 	public List<Post> getPosts() {
 		return posts;

--- a/src/model/fbdata/Interaction.java
+++ b/src/model/fbdata/Interaction.java
@@ -48,4 +48,38 @@ public class Interaction {
 		return from.equals(groupUser) || to.equals(groupUser);
 	}
 
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((from == null) ? 0 : from.hashCode());
+		result = prime * result + ((to == null) ? 0 : to.hashCode());
+		result = prime * result + ((type == null) ? 0 : type.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Interaction other = (Interaction) obj;
+		if (from == null) {
+			if (other.from != null)
+				return false;
+		} else if (!from.equals(other.from))
+			return false;
+		if (to == null) {
+			if (other.to != null)
+				return false;
+		} else if (!to.equals(other.to))
+			return false;
+		if (type != other.type)
+			return false;
+		return true;
+	}
+
 }

--- a/src/model/fbdata/Interaction.java
+++ b/src/model/fbdata/Interaction.java
@@ -44,4 +44,8 @@ public class Interaction {
 		return to.equals(from);
 	}
 
+	public boolean envolvesUser(User groupUser) {
+		return from.equals(groupUser) || to.equals(groupUser);
+	}
+
 }

--- a/src/model/fbdata/Post.java
+++ b/src/model/fbdata/Post.java
@@ -133,6 +133,12 @@ public class Post {
 		return withTagsInteractions;
 	}
 
+	public Long getGroupID() {
+		int endOfGroupIDIndex = id.indexOf("_");
+		String groupId = id.substring(0, endOfGroupIDIndex);
+		return Long.parseLong(groupId);
+	}
+
 	public static void main(String[] args)
 			throws JsonParseException, JsonMappingException, IOException {
 		ObjectMapper mapper = new ObjectMapper();

--- a/src/model/fbdata/Post.java
+++ b/src/model/fbdata/Post.java
@@ -77,18 +77,13 @@ public class Post {
 		return messageTags.getTags();
 	}
 
-	@Override
-	public String toString() {
-		return "Post [author=" + author + ", \nlikes=" + getUsersWhoLiked()
-				+ ", \ncomments=" + getComments() + "]";
-	}
-
 	public Collection<Interaction> getInteractions() {
 		List<Interaction> interactions = new LinkedList<Interaction>();
 		interactions.addAll(getLikesInteractions());
 		interactions.addAll(getCommentsInteractions());
 		interactions.addAll(getStoryTagsInteractions());
 		interactions.addAll(getWithTagsInteractions());
+		interactions.addAll(getMessageTagsInteractions());
 		return interactions;
 	}
 
@@ -133,10 +128,28 @@ public class Post {
 		return withTagsInteractions;
 	}
 
+	private Collection<Interaction> getMessageTagsInteractions() {
+		List<Interaction> messageTagsInteractions = new ArrayList<Interaction>(
+				getMessageTags().size());
+		for (Tag tag : getMessageTags()) {
+			messageTagsInteractions.add(
+					new Interaction(author, tag.getUserTagged(), Type.TAG));
+		}
+		return messageTagsInteractions;
+	}
+
 	public Long getGroupID() {
 		int endOfGroupIDIndex = id.indexOf("_");
 		String groupId = id.substring(0, endOfGroupIDIndex);
 		return Long.parseLong(groupId);
+	}
+
+	@Override
+	public String toString() {
+		return "Post [id=" + id + ", author=" + author + ", \npostComments="
+				+ postComments + ", \npostLikes=" + postLikes + ", \nstoryTags="
+				+ storyTags + ", \nwithTags=" + withTags + ", \nmessageTags="
+				+ messageTags + "]";
 	}
 
 	public static void main(String[] args)

--- a/src/model/fbdata/User.java
+++ b/src/model/fbdata/User.java
@@ -41,22 +41,22 @@ public class User {
 		final int prime = 31;
 		int result = 1;
 		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		result = prime * result + ((name == null) ? 0 : name.hashCode());
 		return result;
 	}
 
 	@Override
 	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
 		User other = (User) obj;
 		if (id == null) {
 			if (other.id != null)
 				return false;
 		} else if (!id.equals(other.id))
-			return false;
-		if (name == null) {
-			if (other.name != null)
-				return false;
-		} else if (!name.equals(other.name))
 			return false;
 		return true;
 	}

--- a/src/model/graph/GroupNetworkGraph.java
+++ b/src/model/graph/GroupNetworkGraph.java
@@ -24,11 +24,19 @@ public class GroupNetworkGraph {
 	 *         otherwise
 	 */
 	public boolean addNode(User user) {
-		if (!nodes.containsKey(user)) {
+		if (canAddNode(user)) {
 			nodes.put(user, new Node(user));
 			return true;
 		}
 		return false;
+	}
+
+	private boolean canAddNode(User user) {
+		return !nodes.containsKey(user) && !isGroupUser(user);
+	}
+
+	private boolean isGroupUser(User user) {
+		return user.getId().equals(groupId);
 	}
 
 	/**
@@ -38,11 +46,16 @@ public class GroupNetworkGraph {
 	 *         <tt>false</tt> otherwise.
 	 */
 	public boolean addInteraction(Interaction interaction) {
-		if (!interaction.isSelfInteraction()) {
+		if (canAddInteraction(interaction)) {
 			doAddInteraction(interaction);
 			return true;
 		}
 		return false;
+	}
+	
+	private boolean canAddInteraction(Interaction interaction) {
+		User groupUser = new User(groupId, "");
+		return !interaction.isSelfInteraction() && !interaction.envolvesUser(groupUser);
 	}
 
 	private void doAddInteraction(Interaction interaction) {

--- a/src/model/graph/GroupNetworkGraph.java
+++ b/src/model/graph/GroupNetworkGraph.java
@@ -13,6 +13,12 @@ public class GroupNetworkGraph {
 
 	private Integer numEdges = 0;
 
+	private Long groupId;
+
+	public GroupNetworkGraph(Long groupId) {
+		this.groupId = groupId;
+	}
+
 	/**
 	 * @return <tt>true</tt> if the node was added successfully, <tt>false</tt>
 	 *         otherwise
@@ -75,6 +81,10 @@ public class GroupNetworkGraph {
 
 	public Integer getNumNodes() {
 		return nodes.size();
+	}
+
+	public Long getGroupId() {
+		return groupId;
 	}
 
 }

--- a/src/model/graph/Interactions.java
+++ b/src/model/graph/Interactions.java
@@ -9,7 +9,7 @@ public class Interactions {
 	private Integer totalTags = 0;
 	private Integer totalLikes = 0;
 
-	public void add(Interaction.Type interactionType) {
+	protected void add(Interaction.Type interactionType) {
 		addToSpecificTypeCount(interactionType);
 		total += 1;
 	}

--- a/src/model/graph/Main.java
+++ b/src/model/graph/Main.java
@@ -2,6 +2,7 @@ package model.graph;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.security.acl.Group;
 import java.util.List;
 
 import com.fasterxml.jackson.core.JsonParseException;
@@ -34,9 +35,7 @@ public class Main {
 	}
 
 	private static void addUsers() throws Exception {
-		for (User user : retrieveUsers()) {
-			graph.addNode(user);
-		}
+		retrieveUsers().forEach(u -> graph.addNode(u));
 	}
 
 	private static List<User> retrieveUsers()
@@ -49,21 +48,10 @@ public class Main {
 
 	private static void addInteractions()
 			throws JsonParseException, JsonMappingException, IOException {
-		List<Post> posts = retrievePosts();
+		List<Post> posts = GroupFeed.retrieveAllPosts();
 		System.out.println("Total posts:" + posts.size());
-		for (Post post : posts) {
-			for (Interaction interaction : post.getInteractions()) {
-				graph.addInteraction(interaction);
-			}
-		}
-	}
-
-	private static List<Post> retrievePosts()
-			throws IOException, JsonParseException, JsonMappingException {
-		InputStream is = GroupFeed.class
-				.getResourceAsStream("/data/maristao.json");
-		return mapper.readValue(is, mapper.getTypeFactory()
-				.constructCollectionLikeType(List.class, Post.class));
+		posts.forEach(
+				p -> p.getInteractions().forEach(i -> graph.addInteraction(i)));
 	}
 
 }

--- a/src/model/graph/Main.java
+++ b/src/model/graph/Main.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.security.acl.Group;
 import java.util.List;
+import java.util.Set;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -27,6 +28,7 @@ public class Main {
 		addInteractions();
 		FunWithBasicStats stats = new FunWithBasicStats(graph);
 		stats.show();
+		printUsersNotInTheGroupAnymore();
 	}
 
 	private static void setUpMapper() {
@@ -35,7 +37,9 @@ public class Main {
 	}
 
 	private static void addUsers() throws Exception {
-		retrieveUsers().forEach(u -> graph.addNode(u));
+		final List<User> users = retrieveUsers();
+		System.out.println("Users: " + users.size());
+		users.forEach(u -> graph.addNode(u));
 	}
 
 	private static List<User> retrieveUsers()
@@ -52,6 +56,16 @@ public class Main {
 		System.out.println("Total posts:" + posts.size());
 		posts.forEach(
 				p -> p.getInteractions().forEach(i -> graph.addInteraction(i)));
+	}
+
+	private static void printUsersNotInTheGroupAnymore()
+			throws JsonParseException, JsonMappingException, IOException {
+		Set<User> usersNotInMembersJson = graph.getUsers();
+		usersNotInMembersJson.removeAll(retrieveUsers());
+		System.out.println(
+				"Users with Facebook probably deleted or not in the group anymore: "
+						+ usersNotInMembersJson.size());
+		System.out.println(usersNotInMembersJson);
 	}
 
 }

--- a/src/model/graph/Main.java
+++ b/src/model/graph/Main.java
@@ -18,7 +18,7 @@ public class Main {
 
 	private static ObjectMapper mapper = new ObjectMapper();
 
-	private static GroupNetworkGraph graph = new GroupNetworkGraph();
+	private static GroupNetworkGraph graph;
 
 	public static void main(String[] args) throws Exception {
 		loadTheGraph();
@@ -28,7 +28,6 @@ public class Main {
 	private static void loadTheGraph() throws Exception, JsonParseException,
 			JsonMappingException, IOException {
 		setUpMapper();
-		addUsers();
 		addInteractions();
 	}
 
@@ -37,26 +36,22 @@ public class Main {
 				false);
 	}
 
-	private static void addUsers() throws Exception {
-		final List<User> users = retrieveUsers();
-		System.out.println("Users: " + users.size());
-		users.forEach(u -> graph.addNode(u));
-	}
-
-	private static List<User> retrieveUsers()
-			throws JsonParseException, JsonMappingException, IOException {
-		InputStream is = Main.class
-				.getResourceAsStream("/data/maristao_members.json");
-		return mapper.readValue(is, mapper.getTypeFactory()
-				.constructCollectionLikeType(List.class, User.class));
-	}
-
 	private static void addInteractions()
 			throws JsonParseException, JsonMappingException, IOException {
 		List<Post> posts = GroupFeed.retrieveAllPosts();
+		instantiateTheGraph(posts);
 		System.out.println("Total posts:" + posts.size());
 		posts.forEach(
 				p -> p.getInteractions().forEach(i -> graph.addInteraction(i)));
+	}
+
+	private static void instantiateTheGraph(List<Post> posts) {
+		Long groupID = getGroupId(posts);
+		graph = new GroupNetworkGraph(groupID);
+	}
+
+	private static Long getGroupId(List<Post> posts) {
+		return posts.get(0).getGroupID();
 	}
 
 	private static void showStats()
@@ -74,6 +69,14 @@ public class Main {
 				"Users with Facebook probably deleted or not in the group anymore: "
 						+ usersNotInMembersJson.size());
 		System.out.println(usersNotInMembersJson);
+	}
+
+	private static List<User> retrieveUsers()
+			throws JsonParseException, JsonMappingException, IOException {
+		InputStream is = Main.class
+				.getResourceAsStream("/data/maristao_members.json");
+		return mapper.readValue(is, mapper.getTypeFactory()
+				.constructCollectionLikeType(List.class, User.class));
 	}
 
 }

--- a/src/model/graph/Main.java
+++ b/src/model/graph/Main.java
@@ -2,7 +2,6 @@ package model.graph;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.security.acl.Group;
 import java.util.List;
 import java.util.Set;
 
@@ -12,7 +11,6 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import model.fbdata.GroupFeed;
-import model.fbdata.Interaction;
 import model.fbdata.Post;
 import model.fbdata.User;
 
@@ -23,12 +21,15 @@ public class Main {
 	private static GroupNetworkGraph graph = new GroupNetworkGraph();
 
 	public static void main(String[] args) throws Exception {
+		loadTheGraph();
+		showStats();
+	}
+
+	private static void loadTheGraph() throws Exception, JsonParseException,
+			JsonMappingException, IOException {
 		setUpMapper();
 		addUsers();
 		addInteractions();
-		FunWithBasicStats stats = new FunWithBasicStats(graph);
-		stats.show();
-		printUsersNotInTheGroupAnymore();
 	}
 
 	private static void setUpMapper() {
@@ -56,6 +57,13 @@ public class Main {
 		System.out.println("Total posts:" + posts.size());
 		posts.forEach(
 				p -> p.getInteractions().forEach(i -> graph.addInteraction(i)));
+	}
+
+	private static void showStats()
+			throws JsonParseException, JsonMappingException, IOException {
+		FunWithBasicStats stats = new FunWithBasicStats(graph);
+		stats.show();
+		printUsersNotInTheGroupAnymore();
 	}
 
 	private static void printUsersNotInTheGroupAnymore()

--- a/src/model/graph/Node.java
+++ b/src/model/graph/Node.java
@@ -48,6 +48,14 @@ public class Node {
 		interactions.add(interactionType);
 	}
 
+	public Interactions getInteractionsWith(User user) {
+		Node userNode = new Node(user);
+		if (neighborsInteractedWith.containsKey(userNode))
+			return neighborsInteractedWith.get(userNode);
+		else
+			return new Interactions();
+	}
+
 	public Set<Node> getNeighbors() {
 		return neighborsInteractedWith.keySet();
 	}

--- a/test/data/feed.json
+++ b/test/data/feed.json
@@ -1,7 +1,7 @@
 {
   "data": [
     {
-      "id": "groupId_postId1",
+      "id": "777_postId1",
       "from": {
         "name": "diego",
         "id": "666"
@@ -11,7 +11,7 @@
           {
             "name": "GROUP",
             "privacy": "SECRET",
-            "id": "groupId"
+            "id": "777"
           },
           {
             "name": "murillo",
@@ -72,15 +72,15 @@
       "actions": [
         {
           "name": "Comment",
-          "link": "https://www.facebook.com/groupId/posts/postId1"
+          "link": "https://www.facebook.com/777/posts/postId1"
         },
         {
           "name": "Like",
-          "link": "https://www.facebook.com/groupId/posts/postId1"
+          "link": "https://www.facebook.com/777/posts/postId1"
         },
         {
           "name": "Create Group Chat",
-          "link": "https://www.facebook.com/groups/groupId/"
+          "link": "https://www.facebook.com/groups/777/"
         }
       ],
       "privacy": {
@@ -155,7 +155,7 @@
       }
     },
     {
-      "id": "groupId_postId2",
+      "id": "777_postId2",
       "from": {
         "name": "diego",
         "id": "666"
@@ -165,7 +165,7 @@
           {
             "name": "GROUP",
             "privacy": "SECRET",
-            "id": "groupId"
+            "id": "777"
           }
         ]
       },
@@ -173,15 +173,15 @@
       "actions": [
         {
           "name": "Comment",
-          "link": "https://www.facebook.com/groupId/posts/postId2"
+          "link": "https://www.facebook.com/777/posts/postId2"
         },
         {
           "name": "Like",
-          "link": "https://www.facebook.com/groupId/posts/postId2"
+          "link": "https://www.facebook.com/777/posts/postId2"
         },
         {
           "name": "Create Group Chat",
-          "link": "https://www.facebook.com/groups/groupId/"
+          "link": "https://www.facebook.com/groups/777/"
         }
       ],
       "privacy": {
@@ -235,7 +235,7 @@
       }
     },
     {
-      "id": "groupId_postId3",
+      "id": "777_postId3",
       "from": {
         "name": "diego",
         "id": "666"
@@ -245,7 +245,7 @@
           {
             "name": "GROUP",
             "privacy": "SECRET",
-            "id": "groupId"
+            "id": "777"
           }
         ]
       },
@@ -265,15 +265,15 @@
       "actions": [
         {
           "name": "Comment",
-          "link": "https://www.facebook.com/groupId/posts/postId3"
+          "link": "https://www.facebook.com/777/posts/postId3"
         },
         {
           "name": "Like",
-          "link": "https://www.facebook.com/groupId/posts/postId3"
+          "link": "https://www.facebook.com/777/posts/postId3"
         },
         {
           "name": "Create Group Chat",
-          "link": "https://www.facebook.com/groups/groupId/"
+          "link": "https://www.facebook.com/groups/777/"
         }
       ],
       "privacy": {
@@ -291,7 +291,7 @@
       "is_expired": false
     },
     {
-      "id": "groupId_postId4",
+      "id": "777_postId4",
       "from": {
         "name": "diego",
         "id": "666"
@@ -301,7 +301,7 @@
           {
             "name": "GROUP",
             "privacy": "SECRET",
-            "id": "groupId"
+            "id": "777"
           }
         ]
       },
@@ -318,7 +318,7 @@
         ],
         "33": [
           {
-            "id": "groupId",
+            "id": "777",
             "name": "GROUP",
             "type": "group",
             "offset": 33,
@@ -329,15 +329,15 @@
       "actions": [
         {
           "name": "Comment",
-          "link": "https://www.facebook.com/groupId/posts/postId4"
+          "link": "https://www.facebook.com/777/posts/postId4"
         },
         {
           "name": "Like",
-          "link": "https://www.facebook.com/groupId/posts/postId4"
+          "link": "https://www.facebook.com/777/posts/postId4"
         },
         {
           "name": "Create Group Chat",
-          "link": "https://www.facebook.com/groups/groupId/"
+          "link": "https://www.facebook.com/groups/777/"
         }
       ],
       "privacy": {
@@ -356,7 +356,7 @@
     }
   ],
   "paging": {
-    "previous": "https://graph.facebook.com/v2.3/groupId/feed?format=json&since=1460226318&access_token=CAACEdEose0cBAJQ6cR1L1h6xU8jEwOrEIkUllZA5JIkkdZAalLbHlgG1ZAbXb8BsaPeiDdwKnzGeJbs77iSwZBZB0G0rIXoX78i4vFd36HZCRpJZBkeESB3DKWhg0H8D4oJZAHnGo7ogHbzTZABFZAWMM8UH2FbS6polZBdGLfZC11rIZCuwsZC7RAiwrcZC86qrnFaAa62FZCsrrWwX0gZDZD&limit=25&__paging_token=enc_AdBirZBBGvThZBxZC1RxuBM1RGqgbxeTAHOmvry32iUeGyLire5ZCmRXfYQQbFGCjx1D88ofKbgoJJuZB3wVhsR0mqZAfHV2ZCz5ZCw4SnsLmD5PDcvTLQZDZD&__previous=1",
-    "next": "https://graph.facebook.com/v2.3/groupId/feed?format=json&access_token=CAACEdEose0cBAJQ6cR1L1h6xU8jEwOrEIkUllZA5JIkkdZAalLbHlgG1ZAbXb8BsaPeiDdwKnzGeJbs77iSwZBZB0G0rIXoX78i4vFd36HZCRpJZBkeESB3DKWhg0H8D4oJZAHnGo7ogHbzTZABFZAWMM8UH2FbS6polZBdGLfZC11rIZCuwsZC7RAiwrcZC86qrnFaAa62FZCsrrWwX0gZDZD&limit=25&until=1460153565&__paging_token=enc_AdBw8DENZBAvNZCtI1YGttjHLeivHF60u4XUu6JKedq16NpE25kmNBQh4K7NqNaY0LV0xoqIZADmxvpVji0uZC5yiDXPLI9oZCdmvfYZAFoguM0rAhWAZDZD"
+    "previous": "https://graph.facebook.com/v2.3/777/feed?format=json&since=1460226318&access_token=CAACEdEose0cBAJQ6cR1L1h6xU8jEwOrEIkUllZA5JIkkdZAalLbHlgG1ZAbXb8BsaPeiDdwKnzGeJbs77iSwZBZB0G0rIXoX78i4vFd36HZCRpJZBkeESB3DKWhg0H8D4oJZAHnGo7ogHbzTZABFZAWMM8UH2FbS6polZBdGLfZC11rIZCuwsZC7RAiwrcZC86qrnFaAa62FZCsrrWwX0gZDZD&limit=25&__paging_token=enc_AdBirZBBGvThZBxZC1RxuBM1RGqgbxeTAHOmvry32iUeGyLire5ZCmRXfYQQbFGCjx1D88ofKbgoJJuZB3wVhsR0mqZAfHV2ZCz5ZCw4SnsLmD5PDcvTLQZDZD&__previous=1",
+    "next": "https://graph.facebook.com/v2.3/777/feed?format=json&access_token=CAACEdEose0cBAJQ6cR1L1h6xU8jEwOrEIkUllZA5JIkkdZAalLbHlgG1ZAbXb8BsaPeiDdwKnzGeJbs77iSwZBZB0G0rIXoX78i4vFd36HZCRpJZBkeESB3DKWhg0H8D4oJZAHnGo7ogHbzTZABFZAWMM8UH2FbS6polZBdGLfZC11rIZCuwsZC7RAiwrcZC86qrnFaAa62FZCsrrWwX0gZDZD&limit=25&until=1460153565&__paging_token=enc_AdBw8DENZBAvNZCtI1YGttjHLeivHF60u4XUu6JKedq16NpE25kmNBQh4K7NqNaY0LV0xoqIZADmxvpVji0uZC5yiDXPLI9oZCdmvfYZAFoguM0rAhWAZDZD"
   }
 }

--- a/test/data/feed.json
+++ b/test/data/feed.json
@@ -1,0 +1,362 @@
+{
+  "data": [
+    {
+      "id": "groupId_postId1",
+      "from": {
+        "name": "diego",
+        "id": "666"
+      },
+      "to": {
+        "data": [
+          {
+            "name": "GROUP",
+            "privacy": "SECRET",
+            "id": "groupId"
+          },
+          {
+            "name": "murillo",
+            "id": "123"
+          },
+          {
+            "name": "gustavo",
+            "id": "987"
+          },
+          {
+            "name": "diego",
+            "id": "666"
+          }
+        ]
+      },
+      "with_tags": {
+        "data": [
+          {
+            "name": "murillo",
+            "id": "123"
+          },
+          {
+            "name": "gustavo",
+            "id": "987"
+          }
+        ]
+      },
+      "message": "Post tagging murillo and gustavo.\nAlso in with_tags.",
+      "message_tags": {
+        "15": [
+          {
+            "id": "123",
+            "name": "murillo",
+            "type": "user",
+            "offset": 15,
+            "length": 14
+          }
+        ],
+        "32": [
+          {
+            "id": "987",
+            "name": "gustavo",
+            "type": "user",
+            "offset": 32,
+            "length": 15
+          }
+        ],
+        "89": [
+          {
+            "id": "666",
+            "name": "diego",
+            "type": "user",
+            "offset": 89,
+            "length": 14
+          }
+        ]
+      },
+      "actions": [
+        {
+          "name": "Comment",
+          "link": "https://www.facebook.com/groupId/posts/postId1"
+        },
+        {
+          "name": "Like",
+          "link": "https://www.facebook.com/groupId/posts/postId1"
+        },
+        {
+          "name": "Create Group Chat",
+          "link": "https://www.facebook.com/groups/groupId/"
+        }
+      ],
+      "privacy": {
+        "value": "CUSTOM",
+        "description": "",
+        "friends": "",
+        "allow": "",
+        "deny": ""
+      },
+      "type": "status",
+      "created_time": "2016-04-09T15:19:22+0000",
+      "updated_time": "2016-04-09T18:25:18+0000",
+      "is_hidden": false,
+      "subscribed": true,
+      "is_expired": false,
+      "likes": {
+        "data": [
+          {
+            "id": "666",
+            "name": "diego"
+          }
+        ],
+        "paging": {
+          "cursors": {
+            "before": "MTAxNTMzNDgzNTg5ODUyMjUZD",
+            "after": "MTAxNTMzNDgzNTg5ODUyMjUZD"
+          }
+        }
+      },
+      "comments": {
+        "data": [
+          {
+            "created_time": "2016-04-09T15:19:44+0000",
+            "from": {
+              "name": "diego",
+              "id": "666"
+            },
+            "message": "Comment tagging murillo.",
+            "can_remove": true,
+            "like_count": 0,
+            "message_tags": [
+              {
+                "id": "123",
+                "length": 14,
+                "name": "murillo",
+                "offset": 37,
+                "type": "user"
+              }
+            ],
+            "user_likes": false,
+            "id": "579024952264399"
+          },
+          {
+            "created_time": "2016-04-09T18:25:18+0000",
+            "from": {
+              "name": "murillo",
+              "id": "123"
+            },
+            "message": "WHATUP",
+            "can_remove": true,
+            "like_count": 1,
+            "user_likes": false,
+            "id": "579102535589974"
+          }
+        ],
+        "paging": {
+          "cursors": {
+            "before": "WTI5dGJXVnVkRjlqZAFhKemIzSTZAOVGM1TURJME9UVXlNalkwTXprNU9qRTBOakF5TVRVeE9EUT0ZD",
+            "after": "WTI5dGJXVnVkRjlqZAFhKemIzSTZAOVGM1TVRBeU5UTTFOVGc1T1RjME9qRTBOakF5TWpZAek1UZAz0ZD"
+          }
+        }
+      }
+    },
+    {
+      "id": "groupId_postId2",
+      "from": {
+        "name": "diego",
+        "id": "666"
+      },
+      "to": {
+        "data": [
+          {
+            "name": "GROUP",
+            "privacy": "SECRET",
+            "id": "groupId"
+          }
+        ]
+      },
+      "message": "Post",
+      "actions": [
+        {
+          "name": "Comment",
+          "link": "https://www.facebook.com/groupId/posts/postId2"
+        },
+        {
+          "name": "Like",
+          "link": "https://www.facebook.com/groupId/posts/postId2"
+        },
+        {
+          "name": "Create Group Chat",
+          "link": "https://www.facebook.com/groups/groupId/"
+        }
+      ],
+      "privacy": {
+        "value": "CUSTOM",
+        "description": "",
+        "friends": "",
+        "allow": "",
+        "deny": ""
+      },
+      "type": "status",
+      "created_time": "2016-04-08T22:15:46+0000",
+      "updated_time": "2016-04-09T15:13:36+0000",
+      "is_hidden": false,
+      "subscribed": true,
+      "is_expired": false,
+      "likes": {
+        "data": [
+          {
+            "id": "666",
+            "name": "diego"
+          }
+        ],
+        "paging": {
+          "cursors": {
+            "before": "MTAxNTMzNDgzNTg5ODUyMjUZD",
+            "after": "MTAxNTMzNDgzNTg5ODUyMjUZD"
+          }
+        }
+      },
+      "comments": {
+        "data": [
+          {
+            "created_time": "2016-04-08T22:15:56+0000",
+            "from": {
+              "name": "diego",
+              "id": "666"
+            },
+            "message": "comment",
+            "can_remove": true,
+            "like_count": 0,
+            "user_likes": false,
+            "id": "578732245627003"
+          }
+        ],
+        "paging": {
+          "cursors": {
+            "before": "WTI5dGJXVnVkRjlqZAFhKemIzSTZAOVGM0TnpNeU1qUTFOakkzTURBek9qRTBOakF4TlRNM05UWT0ZD",
+            "after": "WTI5dGJXVnVkRjlqZAFhKemIzSTZAOVGM0TnpNeU1qUTFOakkzTURBek9qRTBOakF4TlRNM05UWT0ZD"
+          }
+        }
+      }
+    },
+    {
+      "id": "groupId_postId3",
+      "from": {
+        "name": "diego",
+        "id": "666"
+      },
+      "to": {
+        "data": [
+          {
+            "name": "GROUP",
+            "privacy": "SECRET",
+            "id": "groupId"
+          }
+        ]
+      },
+      "with_tags": {
+        "data": [
+          {
+            "name": "murillo",
+            "id": "123"
+          },
+          {
+            "name": "gustavo",
+            "id": "987"
+          }
+        ]
+      },
+      "message": "text message on a picture",
+      "actions": [
+        {
+          "name": "Comment",
+          "link": "https://www.facebook.com/groupId/posts/postId3"
+        },
+        {
+          "name": "Like",
+          "link": "https://www.facebook.com/groupId/posts/postId3"
+        },
+        {
+          "name": "Create Group Chat",
+          "link": "https://www.facebook.com/groups/groupId/"
+        }
+      ],
+      "privacy": {
+        "value": "CUSTOM",
+        "description": "",
+        "friends": "",
+        "allow": "",
+        "deny": ""
+      },
+      "type": "status",
+      "created_time": "2016-04-08T22:35:32+0000",
+      "updated_time": "2016-04-08T22:35:32+0000",
+      "is_hidden": false,
+      "subscribed": true,
+      "is_expired": false
+    },
+    {
+      "id": "groupId_postId4",
+      "from": {
+        "name": "diego",
+        "id": "666"
+      },
+      "to": {
+        "data": [
+          {
+            "name": "GROUP",
+            "privacy": "SECRET",
+            "id": "groupId"
+          }
+        ]
+      },
+      "story": "diego created the group GROUP.",
+      "story_tags": {
+        "0": [
+          {
+            "id": "666",
+            "name": "diego",
+            "type": "user",
+            "offset": 0,
+            "length": 14
+          }
+        ],
+        "33": [
+          {
+            "id": "groupId",
+            "name": "GROUP",
+            "type": "group",
+            "offset": 33,
+            "length": 6
+          }
+        ]
+      },
+      "actions": [
+        {
+          "name": "Comment",
+          "link": "https://www.facebook.com/groupId/posts/postId4"
+        },
+        {
+          "name": "Like",
+          "link": "https://www.facebook.com/groupId/posts/postId4"
+        },
+        {
+          "name": "Create Group Chat",
+          "link": "https://www.facebook.com/groups/groupId/"
+        }
+      ],
+      "privacy": {
+        "value": "CUSTOM",
+        "description": "",
+        "friends": "",
+        "allow": "",
+        "deny": ""
+      },
+      "type": "status",
+      "created_time": "2016-04-08T22:01:20+0000",
+      "updated_time": "2016-04-08T22:12:45+0000",
+      "is_hidden": false,
+      "subscribed": true,
+      "is_expired": false
+    }
+  ],
+  "paging": {
+    "previous": "https://graph.facebook.com/v2.3/groupId/feed?format=json&since=1460226318&access_token=CAACEdEose0cBAJQ6cR1L1h6xU8jEwOrEIkUllZA5JIkkdZAalLbHlgG1ZAbXb8BsaPeiDdwKnzGeJbs77iSwZBZB0G0rIXoX78i4vFd36HZCRpJZBkeESB3DKWhg0H8D4oJZAHnGo7ogHbzTZABFZAWMM8UH2FbS6polZBdGLfZC11rIZCuwsZC7RAiwrcZC86qrnFaAa62FZCsrrWwX0gZDZD&limit=25&__paging_token=enc_AdBirZBBGvThZBxZC1RxuBM1RGqgbxeTAHOmvry32iUeGyLire5ZCmRXfYQQbFGCjx1D88ofKbgoJJuZB3wVhsR0mqZAfHV2ZCz5ZCw4SnsLmD5PDcvTLQZDZD&__previous=1",
+    "next": "https://graph.facebook.com/v2.3/groupId/feed?format=json&access_token=CAACEdEose0cBAJQ6cR1L1h6xU8jEwOrEIkUllZA5JIkkdZAalLbHlgG1ZAbXb8BsaPeiDdwKnzGeJbs77iSwZBZB0G0rIXoX78i4vFd36HZCRpJZBkeESB3DKWhg0H8D4oJZAHnGo7ogHbzTZABFZAWMM8UH2FbS6polZBdGLfZC11rIZCuwsZC7RAiwrcZC86qrnFaAa62FZCsrrWwX0gZDZD&limit=25&until=1460153565&__paging_token=enc_AdBw8DENZBAvNZCtI1YGttjHLeivHF60u4XUu6JKedq16NpE25kmNBQh4K7NqNaY0LV0xoqIZADmxvpVji0uZC5yiDXPLI9oZCdmvfYZAFoguM0rAhWAZDZD"
+  }
+}

--- a/test/data/post.json
+++ b/test/data/post.json
@@ -1,6 +1,6 @@
 
     {
-      "id": "groupId_postId",
+      "id": "777_postId",
       "from": {
         "name": "diego",
         "id": "666"
@@ -10,7 +10,7 @@
           {
             "name": "GROUP",
             "privacy": "SECRET",
-            "id": "groupId"
+            "id": "777"
           },
           {
             "name": "murillo",
@@ -67,15 +67,15 @@
       "actions": [
         {
           "name": "Comment",
-          "link": "https://www.facebook.com/groupId/posts/postId"
+          "link": "https://www.facebook.com/777/posts/postId"
         },
         {
           "name": "Like",
-          "link": "https://www.facebook.com/groupId/posts/postId"
+          "link": "https://www.facebook.com/777/posts/postId"
         },
         {
           "name": "Create Group Chat",
-          "link": "https://www.facebook.com/groups/groupId/"
+          "link": "https://www.facebook.com/groups/777/"
         }
       ],
       "privacy": {

--- a/test/model/graph/GroupNetworkGraphParsingTest.java
+++ b/test/model/graph/GroupNetworkGraphParsingTest.java
@@ -1,12 +1,16 @@
 package model.graph;
 
-import static model.graph.JSONTestFileData.*;
+import static model.graph.JSONTestFileData.DIEGO;
+import static model.graph.JSONTestFileData.FEED_FILE_PATH;
+import static model.graph.JSONTestFileData.GROUP_ID;
+import static model.graph.JSONTestFileData.GROUP_USER;
+import static model.graph.JSONTestFileData.GUSTAVO;
+import static model.graph.JSONTestFileData.MURILLO;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -74,8 +78,8 @@ public class GroupNetworkGraphParsingTest {
 
 	@Test
 	public void shouldNotHaveGroupAsANode() {
-		Node userNode = new Node(GROUP_USER);
-		assertThat(graph.getNodes(), not(hasItem(userNode)));
+		Node groupNode = new Node(GROUP_USER);
+		assertThat(graph.getNodes(), not(hasItem(groupNode)));
 	}
 
 	@Test
@@ -85,7 +89,11 @@ public class GroupNetworkGraphParsingTest {
 
 	@Test
 	public void shouldNotHaveInteractionsEnvolvingTheGroupUser() {
-		fail("Test not yet implemented");
+		Node groupNode = new Node(GROUP_USER);
+		Collection<Node> nodes = graph.getNodes();
+		nodes.forEach(
+				n -> assertThat(n.getNeighbors(), not(hasItem(groupNode))));
+
 	}
 
 }

--- a/test/model/graph/GroupNetworkGraphParsingTest.java
+++ b/test/model/graph/GroupNetworkGraphParsingTest.java
@@ -28,7 +28,7 @@ public class GroupNetworkGraphParsingTest {
 
 	private static ObjectMapper mapper;
 
-	private static GroupNetworkGraph graph = new GroupNetworkGraph();
+	private static GroupNetworkGraph graph = new GroupNetworkGraph(GROUP_ID);
 
 	@BeforeClass
 	public static void setUpOnce() throws Exception {
@@ -75,7 +75,8 @@ public class GroupNetworkGraphParsingTest {
 	@Test
 	public void shouldNotHaveGroupAsANode() {
 		User groupUser = new User(GROUP_ID, GROUP_NAME);
-		assertThat(graph.getNodes(), not(hasItem(new Node(groupUser))));
+		Node userNode = new Node(groupUser);
+		assertThat(graph.getNodes(), not(hasItem(userNode)));
 	}
 
 }

--- a/test/model/graph/GroupNetworkGraphParsingTest.java
+++ b/test/model/graph/GroupNetworkGraphParsingTest.java
@@ -9,8 +9,7 @@ import static model.graph.JSONTestFileData.MURILLO;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -93,7 +92,53 @@ public class GroupNetworkGraphParsingTest {
 		Collection<Node> nodes = graph.getNodes();
 		nodes.forEach(
 				n -> assertThat(n.getNeighbors(), not(hasItem(groupNode))));
+	}
 
+	@Test
+	public void shouldHaveCorrectNumberOfEdges() {
+		assertEquals(6, graph.getNumEdges().intValue());
+	}
+
+	@Test
+	public void shouldHaveDiegoTaggingMurilloFourTimes() {
+		Node diegoNode = graph.getUserNode(DIEGO);
+		Interactions i = diegoNode.getInteractionsWith(MURILLO);
+		assertEquals(4, i.getTotalTags().intValue());
+	}
+
+	@Test
+	public void shouldHaveDiegoTaggingGustavoThreeTimes() {
+		Node diegoNode = graph.getUserNode(DIEGO);
+		Interactions i = diegoNode.getInteractionsWith(GUSTAVO);
+		assertEquals(3, i.getTotalTags().intValue());
+	}
+
+	@Test
+	public void shouldHaveCommentFromMurilloToDiego() {
+		Node murilloNode = graph.getUserNode(MURILLO);
+		Interactions i = murilloNode.getInteractionsWith(DIEGO);
+		assertEquals(1, i.getTotalComments().intValue());
+	}
+
+	@Test
+	public void shouldHaveDiegoNodeWithCorrectDegrees() {
+		Node diegoNode = graph.getUserNode(DIEGO);
+		assertEquals(1, diegoNode.getInDegree().intValue());
+		assertEquals(7, diegoNode.getOutDegree().intValue());
+	}
+
+	@Test
+	public void shouldHaveMurilloNodeWithCorrectDegrees() {
+		Node murilloNode = graph.getUserNode(MURILLO);
+		assertEquals(4, murilloNode.getInDegree().intValue());
+		assertEquals(1, murilloNode.getOutDegree().intValue());
+	}
+
+	@Test
+	public void shouldHaveGustavoNodeWithCorrectDegrees() {
+		Node gustavoNode = graph.getUserNode(GUSTAVO);
+		assertEquals(3, gustavoNode.getInDegree().intValue());
+		assertEquals(0, gustavoNode.getOutDegree().intValue());
 	}
 
 }

--- a/test/model/graph/GroupNetworkGraphParsingTest.java
+++ b/test/model/graph/GroupNetworkGraphParsingTest.java
@@ -1,0 +1,7 @@
+package model.graph;
+
+public class GroupNetworkGraphParsingTest {
+	
+	
+	
+}

--- a/test/model/graph/GroupNetworkGraphParsingTest.java
+++ b/test/model/graph/GroupNetworkGraphParsingTest.java
@@ -1,7 +1,81 @@
 package model.graph;
 
+import static model.graph.JSONTestFileData.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import model.fbdata.GroupFeed;
+import model.fbdata.Post;
+import model.fbdata.User;
+
 public class GroupNetworkGraphParsingTest {
-	
-	
-	
+
+	private static ObjectMapper mapper;
+
+	private static GroupNetworkGraph graph = new GroupNetworkGraph();
+
+	@BeforeClass
+	public static void setUpOnce() throws Exception {
+		setUpMapper();
+		loadGraph();
+	}
+
+	private static void setUpMapper() {
+		mapper = new ObjectMapper();
+		mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
+				false);
+	}
+
+	private static List<Post> retrievePosts()
+			throws IOException, JsonParseException, JsonMappingException {
+		InputStream is = GroupNetworkGraphParsingTest.class
+				.getResourceAsStream(FEED_FILE_PATH);
+		GroupFeed feed = mapper.readValue(is, GroupFeed.class);
+		final List<Post> posts = feed.getPosts();
+		return posts;
+	}
+
+	private static void loadGraph()
+			throws IOException, JsonParseException, JsonMappingException {
+		List<Post> posts = retrievePosts();
+		posts.forEach(
+				p -> p.getInteractions().forEach(i -> graph.addInteraction(i)));
+	}
+
+	@Test
+	public void shouldConstructTheGraph() throws Exception {
+		assertNotNull(graph);
+	}
+
+	@Test
+	public void shouldOnlyHaveUsersAsNodes() throws Exception {
+		Collection<Node> nodes = graph.getNodes();
+		assertThat(nodes, hasItem(new Node(DIEGO)));
+		assertThat(nodes, hasItem(new Node(MURILLO)));
+		assertThat(nodes, hasItem(new Node(GUSTAVO)));
+		assertThat(nodes.size(), equalTo(3));
+	}
+
+	@Test
+	public void shouldNotHaveGroupAsANode() {
+		User groupUser = new User(GROUP_ID, GROUP_NAME);
+		assertThat(graph.getNodes(), not(hasItem(new Node(groupUser))));
+	}
+
 }

--- a/test/model/graph/GroupNetworkGraphParsingTest.java
+++ b/test/model/graph/GroupNetworkGraphParsingTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -22,7 +23,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import model.fbdata.GroupFeed;
 import model.fbdata.Post;
-import model.fbdata.User;
 
 public class GroupNetworkGraphParsingTest {
 
@@ -74,9 +74,18 @@ public class GroupNetworkGraphParsingTest {
 
 	@Test
 	public void shouldNotHaveGroupAsANode() {
-		User groupUser = new User(GROUP_ID, GROUP_NAME);
-		Node userNode = new Node(groupUser);
+		Node userNode = new Node(GROUP_USER);
 		assertThat(graph.getNodes(), not(hasItem(userNode)));
+	}
+
+	@Test
+	public void shouldNotHaveGroupAsUser() {
+		assertThat(graph.getUsers(), not(hasItem(GROUP_USER)));
+	}
+
+	@Test
+	public void shouldNotHaveInteractionsEnvolvingTheGroupUser() {
+		fail("Test not yet implemented");
 	}
 
 }

--- a/test/model/graph/GroupNetworkGraphParsingTest.java
+++ b/test/model/graph/GroupNetworkGraphParsingTest.java
@@ -96,7 +96,7 @@ public class GroupNetworkGraphParsingTest {
 
 	@Test
 	public void shouldHaveCorrectNumberOfEdges() {
-		assertEquals(6, graph.getNumEdges().intValue());
+		assertEquals(8, graph.getNumEdges().intValue());
 	}
 
 	@Test

--- a/test/model/graph/GrouphNetworkGraphBehaviorTest.java
+++ b/test/model/graph/GrouphNetworkGraphBehaviorTest.java
@@ -1,7 +1,13 @@
 package model.graph;
 
-import static org.junit.Assert.*;
-import static model.graph.JSONTestFileData.GROUP_ID;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collection;
 
 import org.junit.Test;
 
@@ -11,10 +17,13 @@ import model.fbdata.User;
 
 public class GrouphNetworkGraphBehaviorTest {
 
-	private GroupNetworkGraph graph = new GroupNetworkGraph(GROUP_ID);
+	private static final Long GROUP_ID = 54321L;
 
-	private User u1 = new User(1L, "1");
-	private User u2 = new User(2L, "2");
+	private static final User GROUP_USER = new User(GROUP_ID, "GROUP");
+	private static final User USER_1 = new User(1L, "1");
+	private static final User USER_2 = new User(2L, "2");
+
+	private GroupNetworkGraph graph = new GroupNetworkGraph(GROUP_ID);
 
 	@Test
 	public void shouldReturnTrueWhenAddingAnInteraction() {
@@ -26,7 +35,7 @@ public class GrouphNetworkGraphBehaviorTest {
 	@Test
 	public void shouldReturnFalseAndNotAddSelfInteraction() {
 		boolean successfullyAdded = graph
-				.addInteraction(new Interaction(u1, u1, Type.LIKE));
+				.addInteraction(new Interaction(USER_1, USER_1, Type.LIKE));
 		assertFalse(successfullyAdded);
 		assertEquals(0, graph.getNumEdges().intValue());
 	}
@@ -39,35 +48,35 @@ public class GrouphNetworkGraphBehaviorTest {
 	public void shouldCreateNodesIfTheyDontExistWhenAddingAnInteraction() {
 		graph.addInteraction(commentFromUser1ToUser2());
 
-		assertTrue(graph.hasNodeForUser(u1));
-		assertTrue(graph.hasNodeForUser(u2));
+		assertTrue(graph.hasNodeForUser(USER_1));
+		assertTrue(graph.hasNodeForUser(USER_2));
 	}
 
 	private Interaction commentFromUser1ToUser2() {
-		return new Interaction(u1, u2, Type.COMMENT);
+		return new Interaction(USER_1, USER_2, Type.COMMENT);
 	}
 
 	@Test
 	public void shouldReturnTrueWhenSuccessfullyAddedANode() {
-		boolean successfullyAdded = graph.addNode(u1);
+		boolean successfullyAdded = graph.addNode(USER_1);
 		assertTrue(successfullyAdded);
 	}
 
 	@Test
 	public void shouldReturnFalseWhenAddingAnExistentNode() {
-		graph.addNode(u1);
-		boolean successfullyAdded = graph.addNode(u1);
+		graph.addNode(USER_1);
+		boolean successfullyAdded = graph.addNode(USER_1);
 		assertFalse(successfullyAdded);
 	}
 
 	@Test
 	public void shouldNotCreateNewNodeWhenTryingToAddExistingNode() {
-		graph.addNode(u1);
+		graph.addNode(USER_1);
 		graph.addInteraction(commentFromUser1ToUser2());
-		Node originalNode = graph.getUserNode(u1);
+		Node originalNode = graph.getUserNode(USER_1);
 
-		graph.addNode(u1);
-		Node nodeAddedAgain = graph.getUserNode(u1);
+		graph.addNode(USER_1);
+		Node nodeAddedAgain = graph.getUserNode(USER_1);
 
 		assertThatNodeAddedAgainIsEqualToOriginalNode(originalNode,
 				nodeAddedAgain);
@@ -81,6 +90,60 @@ public class GrouphNetworkGraphBehaviorTest {
 				nodeAddedAgain.getOutDegree());
 		assertEquals(originalNode.getNeighbors(),
 				nodeAddedAgain.getNeighbors());
+	}
+
+	@Test
+	public void shouldReturnFalseWhenAddingGroupNode() {
+		boolean successfullyAdded = graph.addNode(GROUP_USER);
+		assertFalse(successfullyAdded);
+	}
+
+	@Test
+	public void shouldNotAddGroupNode() {
+		graph.addNode(GROUP_USER);
+		assertThat(graph.getNodes(), not(hasItem(new Node(GROUP_USER))));
+	}
+
+	@Test
+	public void shouldNotAddGroupAsAnUser() {
+		graph.addNode(GROUP_USER);
+		assertThat(graph.getUsers(), not(hasItem(GROUP_USER)));
+	}
+
+	@Test
+	public void shouldReturnFalseWhenAddingInteractionToGroup() {
+		Interaction i = new Interaction(USER_1, GROUP_USER, Type.COMMENT);
+		boolean successfullyAdded = graph.addInteraction(i);
+		assertFalse(successfullyAdded);
+	}
+
+	@Test
+	public void shouldReturnFalseWhenAddingInteractionFromGroup() {
+		Interaction i = new Interaction(GROUP_USER, USER_2, Type.LIKE);
+		boolean successfullyAdded = graph.addInteraction(i);
+		assertFalse(successfullyAdded);
+	}
+
+	@Test
+	public void shouldNotAddGroupAsNodeWhenAddingInteractionFromGroup() {
+		Interaction i = new Interaction(GROUP_USER, USER_2, Type.LIKE);
+		graph.addInteraction(i);
+		assertThat(graph.getNodes(), not(hasItem(new Node(GROUP_USER))));
+	}
+
+	@Test
+	public void shouldNotAddGroupAsNodeWhenAddingInteractionToGroup() {
+		Interaction i = new Interaction(USER_1, GROUP_USER, Type.COMMENT);
+		graph.addInteraction(i);
+		assertThat(graph.getNodes(), not(hasItem(new Node(GROUP_USER))));
+	}
+
+	@Test
+	public void shouldNotHaveNodesWithGroupAsNeighborWhenAddingInteractionEnvolvingTheGroup() {
+		Node groupNode = new Node(GROUP_USER);
+		Collection<Node> nodes = graph.getNodes();
+		nodes.forEach(
+				n -> assertThat(n.getNeighbors(), not(hasItem(groupNode))));
 	}
 
 }

--- a/test/model/graph/GrouphNetworkGraphBehaviorTest.java
+++ b/test/model/graph/GrouphNetworkGraphBehaviorTest.java
@@ -1,6 +1,7 @@
 package model.graph;
 
 import static org.junit.Assert.*;
+import static model.graph.JSONTestFileData.GROUP_ID;
 
 import org.junit.Test;
 
@@ -10,7 +11,7 @@ import model.fbdata.User;
 
 public class GrouphNetworkGraphBehaviorTest {
 
-	private GroupNetworkGraph graph = new GroupNetworkGraph();
+	private GroupNetworkGraph graph = new GroupNetworkGraph(GROUP_ID);
 
 	private User u1 = new User(1L, "1");
 	private User u2 = new User(2L, "2");

--- a/test/model/graph/GrouphNetworkGraphBehaviorTest.java
+++ b/test/model/graph/GrouphNetworkGraphBehaviorTest.java
@@ -8,7 +8,7 @@ import model.fbdata.Interaction;
 import model.fbdata.Interaction.Type;
 import model.fbdata.User;
 
-public class GrouphNetworkGraphTest {
+public class GrouphNetworkGraphBehaviorTest {
 
 	private GroupNetworkGraph graph = new GroupNetworkGraph();
 

--- a/test/model/graph/GrouphNetworkGraphTest.java
+++ b/test/model/graph/GrouphNetworkGraphTest.java
@@ -31,6 +31,10 @@ public class GrouphNetworkGraphTest {
 	}
 
 	@Test
+	// This actually happens because some users might have deleted their profile
+	// or they are not in the group anymore, but they were at some point.
+	// Even if not technically in the group, in both situations they are still
+	// present in the Group Feed.
 	public void shouldCreateNodesIfTheyDontExistWhenAddingAnInteraction() {
 		graph.addInteraction(commentFromUser1ToUser2());
 

--- a/test/model/graph/InteractionsTest.java
+++ b/test/model/graph/InteractionsTest.java
@@ -14,18 +14,22 @@ public class InteractionsTest {
 
 	private int previousTotalComments;
 	private int previousTotalTags;
+	private int previousTotalLikes;
 
 	@Before
 	public void setUp() {
 		interactions = new Interactions();
 		previousTotalComments = 0;
 		previousTotalTags = 0;
+		previousTotalLikes = 0;
 	}
 
 	@Test
 	public void shouldAddTotalCorrectlyWhenAddingComments() throws Exception {
 		interactions.add(Type.COMMENT);
 		assertEquals(previousTotalTags, interactions.getTotalTags().intValue());
+		assertEquals(previousTotalLikes,
+				interactions.getTotalLikes().intValue());
 		assertEquals(1, interactions.getTotalComments().intValue());
 		assertEquals(1, interactions.getTotal().intValue());
 	}
@@ -35,7 +39,19 @@ public class InteractionsTest {
 		interactions.add(Type.TAG);
 		assertEquals(previousTotalComments,
 				interactions.getTotalComments().intValue());
+		assertEquals(previousTotalLikes,
+				interactions.getTotalLikes().intValue());
 		assertEquals(1, interactions.getTotalTags().intValue());
+		assertEquals(1, interactions.getTotal().intValue());
+	}
+
+	@Test
+	public void shouldAddTotalCorrectlyWhenAddingLikes() {
+		interactions.add(Type.LIKE);
+		assertEquals(previousTotalComments,
+				interactions.getTotalComments().intValue());
+		assertEquals(previousTotalTags, interactions.getTotalTags().intValue());
+		assertEquals(1, interactions.getTotalLikes().intValue());
 		assertEquals(1, interactions.getTotal().intValue());
 	}
 

--- a/test/model/graph/JSONTestFileData.java
+++ b/test/model/graph/JSONTestFileData.java
@@ -6,9 +6,11 @@ public class JSONTestFileData {
 
 	public static final Long GROUP_ID = 777L;
 
-	public static final String POST_ID_1 = GROUP_ID + "_postId";
-	
 	public static final String GROUP_NAME = "GROUP";
+
+	public static final User GROUP_USER = new User(GROUP_ID, GROUP_NAME);
+
+	public static final String POST_ID_1 = GROUP_ID + "_postId";
 
 	public static final int MURILLO_COMMENT_ID = 1111;
 

--- a/test/model/graph/JSONTestFileData.java
+++ b/test/model/graph/JSONTestFileData.java
@@ -1,0 +1,25 @@
+package model.graph;
+
+import model.fbdata.User;
+
+public class JSONTestFileData {
+
+	public static final String POST_ID_1 = "groupId_postId";
+
+	public static final int MURILLO_COMMENT_ID = 1111;
+
+	public static final long DIEGO_COMMENT_ID = 1000L;
+
+	public static final User GUSTAVO = new User(987L, "gustavo");
+
+	public static final User MURILLO = new User(123L, "murillo");
+
+	public static final User DIEGO = new User(666L, "diego");
+
+	private static final String FILE_DIR = "/data/";
+
+	public static final String POST_FILE_PATH = FILE_DIR + "post.json";
+
+	public static final String FEED_FILE_PATH = FILE_DIR + "feed.json";
+
+}

--- a/test/model/graph/JSONTestFileData.java
+++ b/test/model/graph/JSONTestFileData.java
@@ -4,7 +4,9 @@ import model.fbdata.User;
 
 public class JSONTestFileData {
 
-	public static final String POST_ID_1 = "groupId_postId";
+	public static final Long GROUP_ID = 777L;
+
+	public static final String POST_ID_1 = GROUP_ID + "_postId";
 
 	public static final int MURILLO_COMMENT_ID = 1111;
 

--- a/test/model/graph/JSONTestFileData.java
+++ b/test/model/graph/JSONTestFileData.java
@@ -7,6 +7,8 @@ public class JSONTestFileData {
 	public static final Long GROUP_ID = 777L;
 
 	public static final String POST_ID_1 = GROUP_ID + "_postId";
+	
+	public static final String GROUP_NAME = "GROUP";
 
 	public static final int MURILLO_COMMENT_ID = 1111;
 

--- a/test/model/graph/NodeTest.java
+++ b/test/model/graph/NodeTest.java
@@ -1,39 +1,56 @@
 package model.graph;
 
-import static org.junit.Assert.*;
-import model.fbdata.Interaction;
-import model.fbdata.User;
+import static org.junit.Assert.assertEquals;
 
-import org.junit.Before;
 import org.junit.Test;
+
+import model.fbdata.Interaction.Type;
+import model.fbdata.User;
 
 public class NodeTest {
 
-	private User u1;
-	private User u2;
-	private Node n1;
-	private Node n2;
-
-	@Before
-	public void setUp() {
-		u1 = new User(1L, "1");
-		n1 = new Node(u1);
-		u2 = new User(2L, "2");
-		n2 = new Node(u2);
-	}
+	private User u1 = new User(1L, "1");
+	private User u2 = new User(2L, "2");
+	private Node n1 = new Node(u1);
+	private Node n2 = new Node(u2);
 
 	@Test
-	public void shouldOnlyIncreaseInteractingNodeOutDegree() throws Exception {
-		n1.addInteractionWith(n2, Interaction.Type.TAG);
+	public void shouldOnlyIncreaseInteractingNodeOutDegree() {
+		n1.addInteractionWith(n2, Type.TAG);
 		assertEquals(0, n1.getInDegree().intValue());
 		assertEquals(1, n1.getOutDegree().intValue());
 	}
 
 	@Test
-	public void shouldOnlyIncreaseInteractedNodeInDegree() throws Exception {
-		n1.addInteractionWith(n2, Interaction.Type.TAG);
+	public void shouldOnlyIncreaseInteractedNodeInDegree() {
+		n1.addInteractionWith(n2, Type.TAG);
 		assertEquals(1, n2.getInDegree().intValue());
 		assertEquals(0, n2.getOutDegree().intValue());
 	}
 
+	@Test
+	public void shouldReturnInteractionsWithUser() {
+		n1.addInteractionWith(n2, Type.COMMENT);
+		n1.addInteractionWith(n2, Type.COMMENT);
+		n1.addInteractionWith(n2, Type.TAG);
+		n1.addInteractionWith(n2, Type.LIKE);
+
+		Interactions interactions = n1.getInteractionsWith(u2);
+
+		assertEquals(4, interactions.getTotal().intValue());
+		assertEquals(2, interactions.getTotalComments().intValue());
+		assertEquals(1, interactions.getTotalLikes().intValue());
+		assertEquals(1, interactions.getTotalTags().intValue());
+	}
+
+	@Test
+	public void shouldReturnEmptyInteractionsWhenUserIsNotANeighbor() {
+		Interactions interactions = n1
+				.getInteractionsWith(new User(33L, "not a neighbor"));
+
+		assertEquals(0, interactions.getTotal().intValue());
+		assertEquals(0, interactions.getTotalComments().intValue());
+		assertEquals(0, interactions.getTotalLikes().intValue());
+		assertEquals(0, interactions.getTotalTags().intValue());
+	}
 }

--- a/test/model/graph/PostTest.java
+++ b/test/model/graph/PostTest.java
@@ -49,6 +49,11 @@ public class PostTest {
 	}
 
 	@Test
+	public void shouldReturnTheCorrectGroupID() {
+		assertEquals(GROUP_ID, post.getGroupID());
+	}
+	
+	@Test
 	public void shouldHaveAllWithTags() {
 		List<Tag> withTags = post.getWithTags();
 		assertThat(withTags, hasItem(tag(MURILLO)));

--- a/test/model/graph/PostTest.java
+++ b/test/model/graph/PostTest.java
@@ -6,6 +6,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import static model.graph.JSONTestFileData.*;
+
 import java.io.InputStream;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -23,20 +25,6 @@ import model.fbdata.User;
 
 public class PostTest {
 
-	private static final String POST_ID = "groupId_postId";
-
-	private static final int MURILLO_COMMENT_ID = 1111;
-
-	private static final long DIEGO_COMMENT_ID = 1000L;
-
-	private static final User GUSTAVO = new User(987L, "gustavo");
-
-	private static final User MURILLO = new User(123L, "murillo");
-
-	private static final User DIEGO = new User(666L, "diego");
-
-	private static final String JSON_FILE_PATH = "/data/post.json";
-
 	private static Post post;
 
 	private static ObjectMapper mapper;
@@ -46,13 +34,13 @@ public class PostTest {
 		mapper = new ObjectMapper();
 		mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
 				false);
-		InputStream is = PostTest.class.getResourceAsStream(JSON_FILE_PATH);
+		InputStream is = PostTest.class.getResourceAsStream(POST_FILE_PATH);
 		post = mapper.readValue(is, Post.class);
 	}
 
 	@Test
 	public void shouldParsePostIdCorrectly() {
-		assertEquals(POST_ID, post.getId());
+		assertEquals(POST_ID_1, post.getId());
 	}
 
 	@Test

--- a/test/model/graph/PostTest.java
+++ b/test/model/graph/PostTest.java
@@ -1,12 +1,18 @@
 package model.graph;
 
+import static model.graph.JSONTestFileData.DIEGO;
+import static model.graph.JSONTestFileData.DIEGO_COMMENT_ID;
+import static model.graph.JSONTestFileData.GROUP_ID;
+import static model.graph.JSONTestFileData.GUSTAVO;
+import static model.graph.JSONTestFileData.MURILLO;
+import static model.graph.JSONTestFileData.MURILLO_COMMENT_ID;
+import static model.graph.JSONTestFileData.POST_FILE_PATH;
+import static model.graph.JSONTestFileData.POST_ID_1;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-
-import static model.graph.JSONTestFileData.*;
 
 import java.io.InputStream;
 import java.util.List;
@@ -19,8 +25,10 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import model.fbdata.Comment;
-import model.fbdata.Tag;
+import model.fbdata.Interaction;
+import model.fbdata.Interaction.Type;
 import model.fbdata.Post;
+import model.fbdata.Tag;
 import model.fbdata.User;
 
 public class PostTest {
@@ -52,7 +60,7 @@ public class PostTest {
 	public void shouldReturnTheCorrectGroupID() {
 		assertEquals(GROUP_ID, post.getGroupID());
 	}
-	
+
 	@Test
 	public void shouldHaveAllWithTags() {
 		List<Tag> withTags = post.getWithTags();
@@ -116,6 +124,36 @@ public class PostTest {
 
 	@Test
 	public void shouldHaveAllInteractions() {
-		assertEquals(6, post.getInteractions().size());
+		assertEquals(9, post.getInteractions().size());
 	}
+
+	@Test
+	public void shouldHaveAllCommentsInteractions() {
+		assertThat(post.getInteractions(),
+				hasItem(new Interaction(DIEGO, DIEGO, Type.COMMENT)));
+		assertThat(post.getInteractions(),
+				hasItem(new Interaction(MURILLO, DIEGO, Type.COMMENT)));
+	}
+
+	// Including with_tags, message_tags, and tags on comment
+	// This particular file has:
+	// with_tags: 3
+	// message_tags: 2
+	// comment tag: 1
+	@Test
+	public void shouldHaveAllTagsInteractions() {
+		List<Interaction> tags = post.getInteractions().stream()
+				.filter(i -> i.getType().equals(Type.TAG))
+				.collect(Collectors.toList());
+		assertEquals(6, tags.size());
+	}
+
+	@Test
+	public void shouldHaveAllLikesInteractions() {
+		List<Interaction> likes = post.getInteractions().stream()
+				.filter(i -> i.getType().equals(Type.LIKE))
+				.collect(Collectors.toList());
+		assertEquals(1, likes.size());
+	}
+
 }


### PR DESCRIPTION
This pull request started from tests. The goal was to assure that a group feed JSON extracted directly from Facebook would produce a graph as expected.
A bug was discovered with _Interaction_s from _Post_ and lots of tests were added. 
After this it is possible to have more confidence with the graph and start to pursue some algorithms.
## _User_
- Judging equality only based on ID. We are trusting Facebook on this.
## _Post_
- _getInteractions()_ was not returning Message Tags.
## _Interaction_
- _envolvesUser()_ checks if interaction is from or to the _User_ passed as an argument.
- _hashCode()_  and _equals()_
## _Interactions_
- _add()_ is protected now.
## _Node_
- _getInteractionsWith()_ returns _Interactions_ from the _Node_'s _User_ with other _User_. 
## _GroupNetworkGraph_
- Single constructor taking only the _groupId_. Consequences:
  - A node that has the same ID as the group's will not be added;
  - An interaction that involves an _User_ with the same ID as the group's will not be added.
  - _Main_ class does not add users before reading the group feed anymore. It reads the first post, then instantiate the graph, and finally proceeds to add posts' interactions.
## _GroupFeed_
- _posts_ was exposed a public field. It likes its privacy now. 
